### PR TITLE
updated compiler in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build using DPC++ 2023.0.0 as:
 
 ```shell
 source /opt/intel/oneapi/compiler/2023.0.0/env/vars.sh
-cmake -Bbuild -DCMAKE_CXX_COMPILER=${ONEAPI_ROOT}/compiler/latest/linux/bin-llvm/clang++ -DCMAKE_C_COMPILER=${ONEAPI_ROOT}/compiler/latest/linux/bin-llvm/clang -DSYCLFFT_BUILD_TESTS=ON -DSYCLFFT_BUILD_BENCHMARKS=ON
+cmake -Bbuild -DCMAKE_CXX_COMPILER=${ONEAPI_ROOT}/compiler/2023.0.0/linux/bin-llvm/clang++ -DCMAKE_C_COMPILER=${ONEAPI_ROOT}/compiler/2023.0.0/linux/bin-llvm/clang -DSYCLFFT_BUILD_TESTS=ON -DSYCLFFT_BUILD_BENCHMARKS=ON
 cmake --build build
 ```
 


### PR DESCRIPTION
Changed the compiler from `dpcpp` to `clang++` shipped alongside `dpcpp` to avoid blocked bitcode generation. Updated the readme accordingly

When compiling with `icpx` with optimizations enabled (`-O2` and above), one would get the following error when compiling for Nvidia or AMD backends - 
```
LLVM ERROR: Bitcode output disabled because proprietary optimizations have been performed.
```
thus using the workaround as mentioned here - https://developer.codeplay.com/products/oneapi/nvidia/2023.0.0/guides/troubleshooting#bitcode-output-disabled-with-icpx