### PR TITLE
Fix benchmarks

### DIFF
--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -61,7 +61,7 @@ foreach(BENCHMARK_FILE ${SYCL_FFT_BENCHMARKS})
 endforeach()
 
 if(${SYCLFFT_ENABLE_CUFFT_BENCHMARKS})
-    add_executable(bench_cufft cufft.cpp)
+    add_executable(bench_cufft bench_cufft.cpp)
     find_package(CUDAToolkit REQUIRED)
     target_link_libraries(bench_cufft PRIVATE CUDA::cudart CUDA::cufft benchmark::benchmark)
     target_include_directories(bench_cufft PRIVATE ${PROJECT_SOURCE_DIR}/test/common)

--- a/test/bench/bench_cufft.cpp
+++ b/test/bench/bench_cufft.cpp
@@ -277,11 +277,11 @@ std::vector<T> vec(std::initializer_list<T> init) {
 
 #define BENCH_COMPLEX_FLOAT(...)                                     \
   BENCHMARK_CAPTURE(cufft_oop_real_time_complex_float, __VA_ARGS__); \
-  BENCHMARK_CAPTURE(cufft_oop_device_time_complex_float, __VA_ARGS__)
+  BENCHMARK_CAPTURE(cufft_oop_device_time_complex_float, __VA_ARGS__)->UseManualTime()
 
 #define BENCH_SINGLE_FLOAT(...)                              \
   BENCHMARK_CAPTURE(cufft_oop_real_time_float, __VA_ARGS__); \
-  BENCHMARK_CAPTURE(cufft_oop_device_time_float, __VA_ARGS__)
+  BENCHMARK_CAPTURE(cufft_oop_device_time_float, __VA_ARGS__)->UseManualTime()
 
 // clang-format off
 // Forward, float, out-of-place only:

--- a/test/bench/register_manual_bench.hpp
+++ b/test/bench/register_manual_bench.hpp
@@ -252,19 +252,19 @@ void register_benchmark(const std::string_view& desc_str) {
     fill_descriptor(arg_map, desc);
     benchmark::RegisterBenchmark(real_bench_name.str().c_str(),
                                  bench_dft_real_time<ftype, domain::COMPLEX>,
-                                 desc);
+                                 desc)->UseManualTime();
     benchmark::RegisterBenchmark(device_bench_name.str().c_str(),
                                  bench_dft_device_time<ftype, domain::COMPLEX>,
-                                 desc);
+                                 desc)->UseManualTime();
   } else if (domain == domain::REAL) {
     descriptor<ftype, domain::REAL> desc{lengths};
     fill_descriptor(arg_map, desc);
     benchmark::RegisterBenchmark(real_bench_name.str().c_str(),
                                  bench_dft_real_time<ftype, domain::REAL>,
-                                 desc);
+                                 desc)->UseManualTime();
     benchmark::RegisterBenchmark(device_bench_name.str().c_str(),
                                  bench_dft_device_time<ftype, domain::REAL>,
-                                 desc);
+                                 desc)->UseManualTime();
   } else {
     throw bench_error{"Unexpected domain: ", static_cast<int>(domain)};
   }


### PR DESCRIPTION
Small fixes for benchmarks: correct cpp file in cmakelists for cuFFT benchmark and calling `UseManualTime()` for benchmarks that manually measure time.