### PR TITLE
Updpate to oneapi package 2023.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ SYCL-FFT is in early stages of development and will support more options and opt
 
 Clone SYCL-FFT and run the following commands from the cloned repository.
 
-Build using DPC++ 2023.0.0 as:
+Build using DPC++ 2023.1.0 as:
 
 ```shell
-source /opt/intel/oneapi/compiler/2023.0.0/env/vars.sh
-cmake -Bbuild -DCMAKE_CXX_COMPILER=${ONEAPI_ROOT}/compiler/2023.0.0/linux/bin-llvm/clang++ -DCMAKE_C_COMPILER=${ONEAPI_ROOT}/compiler/2023.0.0/linux/bin-llvm/clang -DSYCLFFT_BUILD_TESTS=ON -DSYCLFFT_BUILD_BENCHMARKS=ON
+source /opt/intel/oneapi/compiler/2023.1.0/env/vars.sh
+cmake -Bbuild -DCMAKE_CXX_COMPILER=${ONEAPI_ROOT}/compiler/2023.1.0/linux/bin-llvm/clang++ -DCMAKE_C_COMPILER=${ONEAPI_ROOT}/compiler/2023.1.0/linux/bin-llvm/clang -DSYCLFFT_BUILD_TESTS=ON -DSYCLFFT_BUILD_BENCHMARKS=ON
 cmake --build build
 ```
 
@@ -61,7 +61,7 @@ Use the `--help` flag to print help message on the configuration syntax.
 
 The library should compile without error on our supported platforms.
 If you run into trouble, or think you have found a bug, we have a support
-forum available through the [ComputeCpp website], or create an issue on GitHub.
+forum available through the [developer website], or create an issue on GitHub.
 
 ## Maintainers
 
@@ -75,6 +75,6 @@ welcome! If you have an idea for a new feature or a fix, please get in
 contact.
 
 [DPC++]: https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top.html
-[ComputeCpp website]: https://developer.codeplay.com
+[developer website]: https://developer.codeplay.com
 [Codeplay Software Ltd]: https://www.codeplay.com
 [DPC++ compiler documentation page]: https://intel.github.io/llvm-docs/UsersManual.html

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -26,10 +26,10 @@
 
 include_guard()
 
-# Try to find a DPC++ release 
+# Try to find a DPC++ release
 # (reqrs source /opt/intel/oneapi/compilers/2023.0.0/env/vars.sh)
-find_package(IntelDPCPP QUIET)
-if(IntelDPCPP_FOUND)
+find_package(IntelSYCL QUIET)
+if(IntelSYCL_FOUND)
     function(add_sycl_to_target)
     set(options)
     set(one_value_args TARGET)
@@ -39,19 +39,20 @@ if(IntelDPCPP_FOUND)
       "${multi_value_args}"
       ${ARGN}
     )
-    set(COMPILE_FLAGS "-fsycl-targets=${SYCLFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda")
-    target_compile_options(${ARG_TARGET} PUBLIC ${COMPILE_FLAGS})   
+    set(COMPILE_FLAGS "-fsycl;-fsycl-targets=${SYCLFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda")
+    target_compile_options(${ARG_TARGET} PUBLIC ${COMPILE_FLAGS})
     target_link_options(${ARG_TARGET} PUBLIC ${COMPILE_FLAGS})
     endfunction()
 endif()
 
 # Try to find DPC++ (nightly or manually set compiler path)
-if(NOT IntelDPCPP_FOUND)
+if(NOT IntelSYCL_FOUND)
     find_package(DPCPP QUIET)
 endif()
 
-if(NOT IntelDPCPP_FOUND AND NOT DPCPP_FOUND)
+if(NOT IntelSYCL_FOUND AND NOT DPCPP_FOUND)
   # Display warnings
+  find_package(IntelSYCL)
   find_package(DPCPP)
   message(FATAL_ERROR "No SYCL implementation found")
 endif()


### PR DESCRIPTION
Update the documentation and the CMake to use the latest oneAPI release.
`-fsycl` seems to be needed now to avoid `clang++: error: '-fsycl-targets' must be used in conjunction with '-fsycl' to enable offloading`.