### PR TITLE
Fix seg-fault in sub-group implementation

### DIFF
--- a/src/general/dispatcher.hpp
+++ b/src/general/dispatcher.hpp
@@ -133,7 +133,7 @@ inline void subgroup_impl(int factor_sg, T_in input, T_out output, const sycl::l
 
   for (std::size_t i = id_of_fft_in_kernel; i < rounded_up_n_ffts; i += n_ffts_in_kernel) {
     bool working = subgroup_local_id < max_wis_working && i < n_transforms;
-    int n_ffts_worked_on_by_sg = sycl::min(static_cast<int>(n_transforms - (i - id_of_fft_in_kernel)), n_ffts_per_sg);
+    int n_ffts_worked_on_by_sg = sycl::min(static_cast<int>(n_transforms - (i - id_of_fft_in_sg)), n_ffts_per_sg);
 
     global2local<true>(input, loc, n_ffts_worked_on_by_sg * n_reals_per_fft, subgroup_size, subgroup_local_id,
                        n_reals_per_fft * (i - id_of_fft_in_sg), subgroup_id * n_reals_per_sg);


### PR DESCRIPTION
* Bad indexing in sub-group implementation leads to reads/writes outside of the bounds of the data allocations.
* Issue was reproduceable on Intel CPU OpenCL
* Fix tested on Intel CPU OpenCL.
* 
## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A]  New headers have an include guards
* [N/A]  API is documented with Doxygen
* [N/A]  New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
