### PR TITLE
use average time for host benchmark

### DIFF
--- a/test/bench/onemkl/bench_closed_onemkl.cpp
+++ b/test/bench/onemkl/bench_closed_onemkl.cpp
@@ -36,6 +36,6 @@ void onemkl_state<prec, domain>::set_out_of_place() {
 }
 
 template <oneapi::mkl::dft::precision prec, oneapi::mkl::dft::domain domain>
-sycl::event onemkl_state<prec, domain>::compute() {
-  return compute_forward(desc, in_dev, out_dev);
+sycl::event onemkl_state<prec, domain>::compute(const std::vector<sycl::event>& deps) {
+  return compute_forward(desc, in_dev, out_dev, deps);
 }

--- a/test/bench/onemkl/bench_open_onemkl.cpp
+++ b/test/bench/onemkl/bench_open_onemkl.cpp
@@ -34,6 +34,6 @@ void onemkl_state<prec, domain>::set_out_of_place() {
 }
 
 template <oneapi::mkl::dft::precision prec, oneapi::mkl::dft::domain domain>
-sycl::event onemkl_state<prec, domain>::compute() {
-  return oneapi::mkl::dft::compute_forward<descriptor_t, forward_t, backward_t>(desc, in_dev, out_dev);
+sycl::event onemkl_state<prec, domain>::compute(const std::vector<sycl::event>& deps) {
+  return oneapi::mkl::dft::compute_forward<descriptor_t, forward_t, backward_t>(desc, in_dev, out_dev, deps);
 }

--- a/test/bench/sycl-fft/bench_float.cpp
+++ b/test/bench/sycl-fft/bench_float.cpp
@@ -22,7 +22,7 @@
 
 #include "launch_bench.hpp"
 
-BENCHMARK(bench_dft_real_time<std::complex<float>>)
+BENCHMARK(bench_dft_average_host_time<std::complex<float>>)
     ->UseManualTime()
     ->Args({16, 8 * 1024 * 1024})
     ->Args({256, 512 * 1024});

--- a/test/bench/sycl-fft/register_manual_bench.hpp
+++ b/test/bench/sycl-fft/register_manual_bench.hpp
@@ -234,23 +234,25 @@ void register_benchmark(const std::string_view& desc_str) {
   }
 
   std::string_view ftype_str = typeid(ftype).name();
-  std::stringstream real_bench_name;
-  std::stringstream device_bench_name;
-  real_bench_name << "real_time," << ftype_str << ":" << desc_str;
-  device_bench_name << "device_time," << ftype_str << ":" << desc_str;
+  std::string host_bench_name;
+  std::string device_bench_name;
+  host_bench_name.append("average_host_time,").append(ftype_str).append(":").append(desc_str);
+  device_bench_name.append("device_time,").append(ftype_str).append(":").append(desc_str);
   if (domain == domain::COMPLEX) {
     descriptor<ftype, domain::COMPLEX> desc{lengths};
     fill_descriptor(arg_map, desc);
-    benchmark::RegisterBenchmark(real_bench_name.str().c_str(), bench_dft_real_time<ftype, domain::COMPLEX>, desc)
+    benchmark::RegisterBenchmark(host_bench_name.c_str(), bench_dft_average_host_time<ftype, domain::COMPLEX>, desc,
+                                 runs_to_average)
         ->UseManualTime();
-    benchmark::RegisterBenchmark(device_bench_name.str().c_str(), bench_dft_device_time<ftype, domain::COMPLEX>, desc)
+    benchmark::RegisterBenchmark(device_bench_name.c_str(), bench_dft_device_time<ftype, domain::COMPLEX>, desc)
         ->UseManualTime();
   } else if (domain == domain::REAL) {
     descriptor<ftype, domain::REAL> desc{lengths};
     fill_descriptor(arg_map, desc);
-    benchmark::RegisterBenchmark(real_bench_name.str().c_str(), bench_dft_real_time<ftype, domain::REAL>, desc)
+    benchmark::RegisterBenchmark(host_bench_name.c_str(), bench_dft_average_host_time<ftype, domain::REAL>, desc,
+                                 runs_to_average)
         ->UseManualTime();
-    benchmark::RegisterBenchmark(device_bench_name.str().c_str(), bench_dft_device_time<ftype, domain::REAL>, desc)
+    benchmark::RegisterBenchmark(device_bench_name.c_str(), bench_dft_device_time<ftype, domain::REAL>, desc)
         ->UseManualTime();
   } else {
     throw bench_error{"Unexpected domain: ", static_cast<int>(domain)};

--- a/test/bench/utils/bench_utils.hpp
+++ b/test/bench/utils/bench_utils.hpp
@@ -32,6 +32,11 @@
 #include "enums.hpp"
 #include "reference_dft.hpp"
 
+/**
+ * @brief number of runs to do when doing an average of many host runs.
+ */
+static constexpr std::size_t runs_to_average = 10;
+
 template <typename integer>
 inline integer get_fwd_per_transform(std::vector<integer> lengths) {
   return std::accumulate(lengths.begin(), lengths.end(), 1, std::multiplies<integer>());


### PR DESCRIPTION
To amortize the cost of any runtime, each kernel can be submitted many times and then we use the time for all the kernels to complete to find the average execution time.

## Checklist

Tick if relevant:

* [ ] New files have a copyright
* [ ] New headers have an include guards
* [ ] API is documented with Doxygen
* [ ] New functionalities are tested
* [ ] Tests pass locally
* [x] Files are clang-formatted
