### PR TITLE
Modify transfer tests to use single precision

### DIFF
--- a/test/unit_test/transfers.cpp
+++ b/test/unit_test/transfers.cpp
@@ -27,7 +27,7 @@
 
 constexpr int N = 8;
 constexpr int wg_size = 64;
-using ftype = double;
+using ftype = float;
 
 class test_transfers_kernel_padded;
 class test_transfers_kernel_unpadded;


### PR DESCRIPTION
Some devices don't support double precision so it would easier to test this with single precision.

## Checklist

Tick if relevant:

* [ ] New files have a copyright
* [ ] New headers have an include guards
* [ ] API is documented with Doxygen
* [ ] New functionalities are tested
* [ ] Tests pass locally
* [x] Files are clang-formatted
