### PR TITLE
[DO NOT MERGE] Rely on spec constants

### DIFF
--- a/src/common/subgroup.hpp
+++ b/src/common/subgroup.hpp
@@ -100,7 +100,7 @@ __attribute__((always_inline)) inline void cross_sg_naive_dft(int N, T& real, T&
     T res_real = 0;
     T res_imag = 0;
 
-    #pragma unroll
+    #pragma clang loop unroll(full)
     for(int idx_in=0; idx_in < N; idx_in++){
     //unrolled_loop<0, N, 1>([&](int idx_in) __attribute__((always_inline)) {
       const T multi_re = twiddle<T>::re[N][idx_in * idx_out % N];

--- a/src/common/subgroup.hpp
+++ b/src/common/subgroup.hpp
@@ -250,7 +250,7 @@ int factorize_sg(int N, int sg_size) {
  * commit
  */
 template <direction dir, int M, int N, typename T_ptr, typename T_twiddles_ptr>
-__attribute__((always_inline)) inline void sg_dft(T_ptr inout, sycl::sub_group& sg, T_twiddles_ptr sg_twiddles) {
+__attribute__((always_inline)) inline void sg_dft(T_ptr inout, T_ptr tmp, sycl::sub_group& sg, T_twiddles_ptr sg_twiddles) {
   using T = detail::remove_ptr<T_ptr>;
   int idx_of_wi_in_fft = sg.get_local_linear_id() % N;
 
@@ -268,7 +268,7 @@ __attribute__((always_inline)) inline void sg_dft(T_ptr inout, sycl::sub_group& 
     real = tmp_real;
   });
 
-  wi_dft<dir, M, 1, 1>(inout, inout);
+  wi_dft<dir, 0>(M, 1, 1, inout, inout, tmp);
 }
 
 /**

--- a/src/common/transfers.hpp
+++ b/src/common/transfers.hpp
@@ -299,7 +299,7 @@ __attribute__((always_inline)) inline void local2global(sycl::nd_item<1> it, T_l
 template <detail::pad Pad, typename T_loc_ptr, typename T_priv_ptr>
 __attribute__((always_inline)) inline void local2private(std::size_t num_elems_per_wi, T_loc_ptr local, T_priv_ptr priv, std::size_t local_id,
                                                          std::size_t stride, std::size_t local_offset = 0) {
-  #pragma unroll
+  #pragma clang loop unroll(full)
   for(int i=0;i< num_elems_per_wi;i++){
     std::size_t local_idx = detail::pad_local<Pad>(local_offset + local_id * stride + i);
     priv[i] = local[local_idx];
@@ -326,7 +326,7 @@ __attribute__((always_inline)) inline void local2private(std::size_t num_elems_p
 template <detail::pad Pad, typename T_priv_ptr, typename T_loc_ptr>
 __attribute__((always_inline)) inline void private2local(std::size_t num_elems_per_wi, T_priv_ptr priv, T_loc_ptr local, std::size_t local_id,
                                                          std::size_t stride, std::size_t local_offset = 0) {
-  #pragma unroll
+  #pragma clang loop unroll(full)
   for(int i=0;i< num_elems_per_wi;i++){
     std::size_t local_idx = detail::pad_local<Pad>(local_offset + local_id * stride + i);
     local[local_idx] = priv[i];

--- a/src/common/transfers.hpp
+++ b/src/common/transfers.hpp
@@ -296,13 +296,14 @@ __attribute__((always_inline)) inline void local2global(sycl::nd_item<1> it, T_l
  * Should be >= num_elems_per_wi
  * @param local_offset offset to the local pointer
  */
-template <std::size_t num_elems_per_wi, detail::pad Pad, typename T_loc_ptr, typename T_priv_ptr>
-__attribute__((always_inline)) inline void local2private(T_loc_ptr local, T_priv_ptr priv, std::size_t local_id,
+template <detail::pad Pad, typename T_loc_ptr, typename T_priv_ptr>
+__attribute__((always_inline)) inline void local2private(std::size_t num_elems_per_wi, T_loc_ptr local, T_priv_ptr priv, std::size_t local_id,
                                                          std::size_t stride, std::size_t local_offset = 0) {
-  detail::unrolled_loop<0, num_elems_per_wi, 1>([&](int i) __attribute__((always_inline)) {
+  #pragma unroll
+  for(int i=0;i< num_elems_per_wi;i++){
     std::size_t local_idx = detail::pad_local<Pad>(local_offset + local_id * stride + i);
     priv[i] = local[local_idx];
-  });
+  }
 }
 
 /**
@@ -322,13 +323,14 @@ __attribute__((always_inline)) inline void local2private(T_loc_ptr local, T_priv
  * Should be >= num_elems_per_wi
  * @param local_offset offset to the local pointer
  */
-template <std::size_t num_elems_per_wi, detail::pad Pad, typename T_priv_ptr, typename T_loc_ptr>
-__attribute__((always_inline)) inline void private2local(T_priv_ptr priv, T_loc_ptr local, std::size_t local_id,
+template <detail::pad Pad, typename T_priv_ptr, typename T_loc_ptr>
+__attribute__((always_inline)) inline void private2local(std::size_t num_elems_per_wi, T_priv_ptr priv, T_loc_ptr local, std::size_t local_id,
                                                          std::size_t stride, std::size_t local_offset = 0) {
-  detail::unrolled_loop<0, num_elems_per_wi, 1>([&](int i) __attribute__((always_inline)) {
+  #pragma unroll
+  for(int i=0;i< num_elems_per_wi;i++){
     std::size_t local_idx = detail::pad_local<Pad>(local_offset + local_id * stride + i);
     local[local_idx] = priv[i];
-  });
+  }
 }
 
 /**

--- a/src/common/workitem.hpp
+++ b/src/common/workitem.hpp
@@ -60,11 +60,11 @@ template <direction dir, typename T_ptr>
 __attribute__((always_inline)) inline void naive_dft(int N, int stride_in, int stride_out, T_ptr in, T_ptr out, T_ptr tmp) {
   using T = remove_ptr<T_ptr>;
   constexpr T TWOPI = 2.0 * M_PI;
-  #pragma unroll
+  #pragma clang loop unroll(full)
   for(int idx_out=0; idx_out<N; idx_out++){
     tmp[2 * idx_out + 0] = 0;
     tmp[2 * idx_out + 1] = 0;
-    #pragma unroll
+    #pragma clang loop unroll(full)
     for(int idx_in=0; idx_in<N; idx_in++){
       // this multiplier is not really a twiddle factor, but it is calculated the same way
       auto re_multiplier = twiddle<T>::re[N][idx_in * idx_out % N];
@@ -80,7 +80,7 @@ __attribute__((always_inline)) inline void naive_dft(int N, int stride_in, int s
           in[2 * idx_in * stride_in] * im_multiplier + in[2 * idx_in * stride_in + 1] * re_multiplier;
     }
   }
-  #pragma unroll
+  #pragma clang loop unroll(full)
   for(int idx_out=0; idx_out<N; idx_out++){
     out[idx_out * stride_out + 0] = tmp[idx_out + 0];
     out[idx_out * stride_out + 1] = tmp[idx_out + 1];
@@ -106,10 +106,10 @@ template <direction dir, int level, typename T_ptr>
 __attribute__((always_inline)) inline void cooley_tukey_dft(int N, int M, int stride_in, int stride_out, T_ptr in, T_ptr out, T_ptr tmp_buffer) {
   using T = remove_ptr<T_ptr>;
 
-  #pragma unroll
+  #pragma clang loop unroll(full)
   for(int i=0;i<M;i++){
     wi_dft<dir, level + 1>(N, M * stride_in, 1, in + 2 * i * stride_in, tmp_buffer + 2 * i * N, tmp_buffer + 2*N*M);
-    #pragma unroll
+    #pragma clang loop unroll(full)
     for(int j=0;j<N;j++){
       auto re_multiplier = twiddle<T>::re[N * M][i * j];
       auto im_multiplier = [&]() {
@@ -122,7 +122,7 @@ __attribute__((always_inline)) inline void cooley_tukey_dft(int N, int M, int st
       tmp_buffer[2 * i * N + 2 * j + 0] = tmp_val;
     }
   }
-  #pragma unroll
+  #pragma clang loop unroll(full)
   for(int i=0;i<N;i++){
     wi_dft<dir, level + 1>(M, N, N * stride_out, tmp_buffer + 2 * i, out + 2 * i * stride_out, tmp_buffer + 2*N*M);
   }

--- a/test/unit_test/transfers.cpp
+++ b/test/unit_test/transfers.cpp
@@ -82,8 +82,8 @@ void test() {
       group_barrier(it.get_group());
       sycl_fft::global2local<Pad, detail::level::WORKGROUP>(it, a_dev_work, loc1_work, N * wg_size);
       group_barrier(it.get_group());
-      sycl_fft::local2private<N, Pad>(loc1_work, priv, local_id, N);
-      sycl_fft::private2local<N, Pad>(priv, loc2_work, local_id, N);
+      sycl_fft::local2private<Pad>(N, loc1_work, priv, local_id, N);
+      sycl_fft::private2local<Pad>(N, priv, loc2_work, local_id, N);
       group_barrier(it.get_group());
       sycl_fft::local2global<Pad, detail::level::WORKGROUP>(it, loc2_work, b_dev_work, N * wg_size);
       group_barrier(it.get_group());


### PR DESCRIPTION
Minimal example of relying on spec constants instead of templates that significantly affects performance.

This PR is NOT intended to be ever merged, only reviewed.

## Checklist

Tick if relevant:

* [ ] New files have a copyright
* [ ] New headers have an include guards
* [ ] API is documented with Doxygen
* [ ] New functionalities are tested
* [ ] Tests pass locally
* [ ] Files are clang-formatted
