### PR TITLE
Add xml output to tests

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -63,5 +63,5 @@ foreach(UNIT_TEST_FILE ${SYCLFFT_UNIT_TESTS})
         Threads::Threads
     )
     target_include_directories(${TEST_TARGET} PRIVATE ${PROJECT_SOURCE_DIR}/test/common)
-    gtest_discover_tests(${TEST_TARGET} DISCOVERY_MODE PRE_TEST)
+    gtest_discover_tests(${TEST_TARGET} XML_OUTPUT_DIR output DISCOVERY_MODE PRE_TEST)
 endforeach()


### PR DESCRIPTION
Enable xml output to be used with JUnit.

## Checklist

Tick if relevant:

* [ ] New files have a copyright
* [ ] New headers have an include guards
* [ ] API is documented with Doxygen
* [ ] New functionalities are tested
* [x] Tests pass locally
* [ ] Files are clang-formatted
