### PR TITLE
Rename cmake variables for portFFT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,40 +35,40 @@ list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules
 )
 
-option(SYCLFFT_BUILD_TESTS "Whether to enable building tests" OFF)
-option(SYCLFFT_BUILD_BENCHMARKS "Whether to enable building benchmarks" OFF)
-option(SYCLFFT_VERIFY_BENCHMARK "Whether to verify FFT results during benchmarking. Verifies in the first iteration only" OFF)
-option(SYCLFFT_GENERATE_BENCH_REFERENCE_AT_BUILD_TIME "Generate benchmark verification data at build-time" ON)
-option(SYCLFFT_ENABLE_DOUBLE_BUILDS "Enable building tests and benchmarks using double precision" ON)
-option(SYCLFFT_USE_SG_TRANSFERS "Whether to use intel extension for subgroup joint loads and stores." OFF)
-option(SYCLFFT_SLOW_SG_SHUFFLES "Whether subgroup shuffles are slow on target device and should be avoided." OFF)
-set(SYCLFFT_TARGET_REGS_PER_WI 128 CACHE STRING "How many 32b registers can be allocated per work item on the target device")
-set(SYCLFFT_SUBGROUP_SIZES 32 CACHE STRING "Comma separated list of subgroup sizes to compile for. The first size supported by the device will be used.")
-set(SYCLFFT_TARGET_WI_LOAD 16 CACHE STRING "Number of consecutive bytes each work item should load at once.")
-set(SYCLFFT_SGS_IN_WG 2 CACHE STRING "Number of subgroups per workgroup.")
-set(SYCLFFT_DEVICE_TRIPLE "spir64" CACHE STRING "Specify the target triple representing target device architectures")
-set(SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES "1,2,3,4,6,8,12,16,24,32,48,64,96,128,192,256,384,512,768,1024,1536,2048,3072,4096,6144,8192" CACHE STRING "Specify the sizes supported in work-item, sub-group, and work-group Cooley-Tukey implementations")
+option(PORTFFT_BUILD_TESTS "Whether to enable building tests" OFF)
+option(PORTFFT_BUILD_BENCHMARKS "Whether to enable building benchmarks" OFF)
+option(PORTFFT_VERIFY_BENCHMARKS "Whether to verify FFT results during benchmarking. Verifies in the first iteration only" OFF)
+option(PORTFFT_GENERATE_BENCH_REFERENCE_AT_BUILD_TIME "Generate benchmark verification data at build-time" ON)
+option(PORTFFT_ENABLE_DOUBLE_BUILDS "Enable building tests and benchmarks using double precision" ON)
+option(PORTFFT_USE_SG_TRANSFERS "Whether to use intel extension for subgroup joint loads and stores." OFF)
+option(PORTFFT_SLOW_SG_SHUFFLES "Whether subgroup shuffles are slow on target device and should be avoided." OFF)
+set(PORTFFT_REGISTERS_PER_WI 128 CACHE STRING "How many 32b registers can be allocated per work item on the target device")
+set(PORTFFT_SUBGROUP_SIZES 32 CACHE STRING "Comma separated list of subgroup sizes to compile for. The first size supported by the device will be used.")
+set(PORTFFT_VEC_LOAD_BYTES 16 CACHE STRING "Number of consecutive bytes each work item should load at once.")
+set(PORTFFT_SGS_IN_WG 2 CACHE STRING "Number of subgroups per workgroup.")
+set(PORTFFT_DEVICE_TRIPLE "spir64" CACHE STRING "Specify the target triple representing target device architectures")
+set(PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES "1,2,3,4,6,8,12,16,24,32,48,64,96,128,192,256,384,512,768,1024,1536,2048,3072,4096,6144,8192" CACHE STRING "Specify the sizes supported in work-item, sub-group, and work-group Cooley-Tukey implementations")
 
-set(SYCLFFT_INCLUDE_DIR
+set(PORTFFT_INCLUDE_DIR
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-set(SYCLFFT_SRC_DIR
+set(PORTFFT_SRC_DIR
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:src>)
 
 add_library(portfft INTERFACE)
 target_include_directories(portfft INTERFACE
-    ${SYCLFFT_INCLUDE_DIR}
-    ${SYCLFFT_SRC_DIR}
+    ${PORTFFT_INCLUDE_DIR}
+    ${PORTFFT_SRC_DIR}
 )
-target_compile_definitions(portfft INTERFACE PORTFFT_TARGET_REGS_PER_WI=${SYCLFFT_TARGET_REGS_PER_WI})
-target_compile_definitions(portfft INTERFACE PORTFFT_SUBGROUP_SIZES=${SYCLFFT_SUBGROUP_SIZES})
-target_compile_definitions(portfft INTERFACE PORTFFT_TARGET_WI_LOAD=${SYCLFFT_TARGET_WI_LOAD})
-target_compile_definitions(portfft INTERFACE PORTFFT_SGS_IN_WG=${SYCLFFT_SGS_IN_WG})
-if(${SYCLFFT_USE_SG_TRANSFERS})
+target_compile_definitions(portfft INTERFACE PORTFFT_REGISTERS_PER_WI=${PORTFFT_REGISTERS_PER_WI})
+target_compile_definitions(portfft INTERFACE PORTFFT_SUBGROUP_SIZES=${PORTFFT_SUBGROUP_SIZES})
+target_compile_definitions(portfft INTERFACE PORTFFT_VEC_LOAD_BYTES=${PORTFFT_VEC_LOAD_BYTES})
+target_compile_definitions(portfft INTERFACE PORTFFT_SGS_IN_WG=${PORTFFT_SGS_IN_WG})
+if(${PORTFFT_USE_SG_TRANSFERS})
   target_compile_definitions(portfft INTERFACE PORTFFT_USE_SG_TRANSFERS)
 endif()
-if(${SYCLFFT_SLOW_SG_SHUFFLES})
+if(${PORTFFT_SLOW_SG_SHUFFLES})
   target_compile_definitions(portfft INTERFACE PORTFFT_SLOW_SG_SHUFFLES=1)
 else()
   target_compile_definitions(portfft INTERFACE PORTFFT_SLOW_SG_SHUFFLES=0)
@@ -86,12 +86,12 @@ write_basic_package_version_file(${version_file}
 )
 
 # Check that the following is a comma separated list.
-if(SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES MATCHES "^[0-9]+(,[0-9]+)*$")
-  message(STATUS "Building with Cooley-Tukey config: " ${SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES})
+if(PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES MATCHES "^[0-9]+(,[0-9]+)*$")
+  message(STATUS "Building with Cooley-Tukey config: " ${PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES})
 else()
-  message(FATAL_ERROR " Invalid SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES value: " ${SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES})
+  message(FATAL_ERROR " Invalid PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES value: " ${PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES})
 endif()
-target_compile_definitions(portfft INTERFACE PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES=${SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES})
+target_compile_definitions(portfft INTERFACE PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES=${PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES})
 
 include(GNUInstallDirs)
 install(TARGETS portfft
@@ -103,8 +103,8 @@ install(TARGETS portfft
 
 install(
   DIRECTORY
-    ${SYCLFFT_INCLUDE_DIR}
-    ${SYCLFFT_SRC_DIR}
+    ${PORTFFT_INCLUDE_DIR}
+    ${PORTFFT_SRC_DIR}
   DESTINATION ${CMAKE_INSTALL_PREFIX}
   COMPONENT portfft
   FILES_MATCHING PATTERN "*.hpp"
@@ -125,7 +125,7 @@ export(EXPORT portfft
 add_library(portfft_warnings INTERFACE)
 target_compile_options(portfft_warnings INTERFACE -Wall -Wextra -Wshadow -Wconversion -Wpedantic)
 
-if(${SYCLFFT_BUILD_TESTS})
+if(${PORTFFT_BUILD_TESTS})
   enable_testing()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -27,29 +27,29 @@ Build using DPC++ 2023.1.0 as:
 
 ```shell
 source /opt/intel/oneapi/compiler/2023.1.0/env/vars.sh
-cmake -Bbuild -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2023.1.0/linux/bin-llvm/clang++ -DCMAKE_C_COMPILER=/opt/intel/oneapi/compiler/2023.1.0/linux/bin-llvm/clang -DSYCLFFT_BUILD_TESTS=ON -DSYCLFFT_BUILD_BENCHMARKS=ON
+cmake -Bbuild -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2023.1.0/linux/bin-llvm/clang++ -DCMAKE_C_COMPILER=/opt/intel/oneapi/compiler/2023.1.0/linux/bin-llvm/clang -DPORTFFT_BUILD_TESTS=ON -DPORTFFT_BUILD_BENCHMARKS=ON
 cmake --build build
 ```
 
 Build using DPC++ nightlies as (SPIR64 target only):
 
 ```shell
-cmake -Bbuild -DCMAKE_CXX_COMPILER=/path/to/dpcpp/bin/clang++ -DCMAKE_C_COMPILER=/path/to/dpcpp/bin/clang -DSYCLFFT_BUILD_TESTS=ON -DSYCLFFT_BUILD_BENCHMARKS=ON
+cmake -Bbuild -DCMAKE_CXX_COMPILER=/path/to/dpcpp/bin/clang++ -DCMAKE_C_COMPILER=/path/to/dpcpp/bin/clang -DPORTFFT_BUILD_TESTS=ON -DPORTFFT_BUILD_BENCHMARKS=ON
 cmake --build build
 ```
 
 To compile AOT for a specific device, specify the target device with:
 
 ```shell
--DSYCLFFT_DEVICE_TRIPLE=<T>[T1,..,Tn]
+-DPORTFFT_DEVICE_TRIPLE=<T>[T1,..,Tn]
 ```
 
 The list of available targets can be found on [DPC++ compiler documentation page].
 Some AOT targets do not support double precision.
-To disable the building of tests and benchmarks using double precision, set `-DSYCLFFT_ENABLE_DOUBLE_BUILDS=OFF`.
+To disable the building of tests and benchmarks using double precision, set `-DPORTFFT_ENABLE_DOUBLE_BUILDS=OFF`.
 
-portFFT currently requires to set the subgroup size at compile time. Multiple sizes can be set and the first one that is supported by the device will be used. Depending on the device used you may need to set the subgroup size with `-DSYCLFFT_SUBGROUP_SIZES=<comma separated list of sizes>`. By default only size 32 is used.
-If you run into the exception with the message `None of the compiled subgroup sizes are supported by the device!` then `DSYCLFFT_SUBGROUP_SIZES` must be set to a different value(s) supported by the device.
+portFFT currently requires to set the subgroup size at compile time. Multiple sizes can be set and the first one that is supported by the device will be used. Depending on the device used you may need to set the subgroup size with `-DPORTFFT_SUBGROUP_SIZES=<comma separated list of sizes>`. By default only size 32 is used.
+If you run into the exception with the message `None of the compiled subgroup sizes are supported by the device!` then `DPORTFFT_SUBGROUP_SIZES` must be set to a different value(s) supported by the device.
 
 ### Tests
 
@@ -88,18 +88,18 @@ portFFT is still in early development. The supported configurations are:
 * 1D transforms only
 
 The supported sizes depend on the CMake flags used which can be constrained by the device used.
-`SYCLFFT_TARGET_REGS_PER_WI` is used to calculate the largest FFT that can fit in a workitem.
+`PORTFFT_VEC_LOAD_BYTES` is used to calculate the largest FFT that can fit in a workitem.
 For instance setting it to `128` (resp. `256`) allows to fit a single precision FFT of size `27` (resp. `56`) in a single workitem.
 
-The FFT sizes supported in the work-item, sub-group and work-group implementations are set using `SYCLFFT_COOLEY_TUKEY_OPTIMIZED_SIZES`.
+The FFT sizes supported in the work-item, sub-group and work-group implementations are set using `PORTFFT_COOLEY_TUKEY_OPTIMIZED_SIZES`.
 The supported sizes are given as a comma-separated list of values.
 By default, the size of $2^n$ and $2^n \times 3$ are enabled up to a value of 8192.
 
-FFT sizes that are a product of a supported workitem FFT size and the subgroup size - the first value from `SYCLFFT_SUBGROUP_SIZES` that is supported by the device - are also supported.
+FFT sizes that are a product of a supported workitem FFT size and the subgroup size - the first value from `PORTFFT_SUBGROUP_SIZES` that is supported by the device - are also supported.
 
 Any batch size is supported as long as the input and output data fits in global memory.
 
-By default the library assumes subgroup size of 32 is used. If that is not supported by the device it is running on, the subgroup size can be set using `SYCLFFT_SUBGROUP_SIZES`.
+By default the library assumes subgroup size of 32 is used. If that is not supported by the device it is running on, the subgroup size can be set using `PORTFFT_SUBGROUP_SIZES`.
 
 ## Known issues
 

--- a/cmake/Modules/FindDPCPP.cmake
+++ b/cmake/Modules/FindDPCPP.cmake
@@ -45,8 +45,8 @@ if(DPCPP_FOUND AND NOT TARGET DPCPP::DPCPP)
   set(CMAKE_CXX_STANDARD 17)
   add_library(DPCPP::DPCPP INTERFACE IMPORTED)
   set_target_properties(DPCPP::DPCPP PROPERTIES
-    INTERFACE_COMPILE_OPTIONS "-fsycl;-fsycl-targets=${SYCLFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda"
-    INTERFACE_LINK_OPTIONS "-fsycl;-fsycl-targets=${SYCLFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda"
+    INTERFACE_COMPILE_OPTIONS "-fsycl;-fsycl-targets=${PORTFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda"
+    INTERFACE_LINK_OPTIONS "-fsycl;-fsycl-targets=${PORTFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda"
     INTERFACE_LINK_LIBRARIES ${DPCPP_LIB}
     INTERFACE_INCLUDE_DIRECTORIES "${DPCPP_BIN_DIR}/../include/sycl;${DPCPP_BIN_DIR}/../include")
 endif()

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -39,7 +39,7 @@ if(IntelSYCL_FOUND)
       "${multi_value_args}"
       ${ARGN}
     )
-    set(COMPILE_FLAGS "-fsycl;-fsycl-targets=${SYCLFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda")
+    set(COMPILE_FLAGS "-fsycl;-fsycl-targets=${PORTFFT_DEVICE_TRIPLE};-fsycl-unnamed-lambda")
     target_compile_options(${ARG_TARGET} PUBLIC ${COMPILE_FLAGS})
     target_link_options(${ARG_TARGET} PUBLIC ${COMPILE_FLAGS})
     endfunction()

--- a/src/common/transfers.hpp
+++ b/src/common/transfers.hpp
@@ -29,8 +29,8 @@
 #define PORTFFT_N_LOCAL_BANKS 32
 #endif
 
-static_assert((PORTFFT_TARGET_WI_LOAD & (PORTFFT_TARGET_WI_LOAD - 1)) == 0,
-              "PORTFFT_TARGET_WI_LOAD should be a power of 2!");
+static_assert((PORTFFT_VEC_LOAD_BYTES & (PORTFFT_VEC_LOAD_BYTES - 1)) == 0,
+              "PORTFFT_VEC_LOAD_BYTES should be a power of 2!");
 
 namespace portfft {
 
@@ -79,7 +79,7 @@ __attribute__((always_inline)) inline void global2local(sycl::nd_item<1> it, con
                                                         std::size_t local_offset = 0) {
   static_assert(Level == detail::level::SUBGROUP || Level == detail::level::WORKGROUP,
                 "Only implemented for subgroup and workgroup levels!");
-  constexpr int chunk_size_raw = PORTFFT_TARGET_WI_LOAD / sizeof(T);
+  constexpr int chunk_size_raw = PORTFFT_VEC_LOAD_BYTES / sizeof(T);
   constexpr int chunk_size = chunk_size_raw < 1 ? 1 : chunk_size_raw;
   using T_vec = sycl::vec<T, chunk_size>;
 
@@ -187,7 +187,7 @@ __attribute__((always_inline)) inline void local2global(sycl::nd_item<1> it, con
                                                         std::size_t global_offset = 0) {
   static_assert(Level == detail::level::SUBGROUP || Level == detail::level::WORKGROUP,
                 "Only implemented for subgroup and workgroup levels!");
-  constexpr int chunk_size_raw = PORTFFT_TARGET_WI_LOAD / sizeof(T);
+  constexpr int chunk_size_raw = PORTFFT_VEC_LOAD_BYTES / sizeof(T);
   constexpr int chunk_size = chunk_size_raw < 1 ? 1 : chunk_size_raw;
   using T_vec = sycl::vec<T, chunk_size>;
 

--- a/src/common/workitem.hpp
+++ b/src/common/workitem.hpp
@@ -169,7 +169,7 @@ template <typename Scalar, typename T_index>
 constexpr bool fits_in_wi(T_index N) {
   T_index N_complex = N + wi_temps(N);
   T_index complex_size = 2 * sizeof(Scalar);
-  T_index register_space = PORTFFT_TARGET_REGS_PER_WI * 4;
+  T_index register_space = PORTFFT_REGISTERS_PER_WI * 4;
   return N_complex * complex_size <= register_space;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,15 +23,15 @@
 # *
 # **************************************************************************/
 
-if(${SYCLFFT_BUILD_TESTS} OR ${SYCLFFT_BUILD_BENCHMARKS})
+if(${PORTFFT_BUILD_TESTS} OR ${PORTFFT_BUILD_BENCHMARKS})
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
 endif()
 
-if(${SYCLFFT_BUILD_TESTS})
+if(${PORTFFT_BUILD_TESTS})
   add_subdirectory(unit_test)
 endif()
 
-if(${SYCLFFT_BUILD_BENCHMARKS})
+if(${PORTFFT_BUILD_BENCHMARKS})
   add_subdirectory(bench)
 endif()

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -38,7 +38,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(googlebenchmark)
 
-if(${SYCLFFT_VERIFY_BENCHMARK})
+if(PORTFFT_VERIFY_BENCHMARKS)
     # Generate benchmark reference data header
     execute_process(
         COMMAND python3 ${CMAKE_SOURCE_DIR}/scripts/generate_reference_data.py --build_path=${CMAKE_BINARY_DIR} --header --benchmark --just_list_outputs 
@@ -61,7 +61,7 @@ if(${SYCLFFT_VERIFY_BENCHMARK})
     add_custom_target(benchmark_reference_data_data 
         DEPENDS ${BENCHMARK_REFERENCE_DATA_DATA_FILES})
         
-    if(NOT SYCLFFT_GENERATE_BENCH_REFERENCE_AT_BUILD_TIME)
+    if(NOT PORTFFT_GENERATE_BENCH_REFERENCE_AT_BUILD_TIME)
       # Generating the actual benchmark data at build time is not a default thing
       # It can be generated with "ninja benchmark_reference_data_data"
       set_target_properties(benchmark_reference_data_data PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -79,18 +79,18 @@ function(add_benchmark target source_file)
   )
 
   # get target include directories from portfft for the direction enum
-  get_target_property(SYCLFFT_INCLUDES portfft INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(PORTFFT_INCLUDES portfft INTERFACE_INCLUDE_DIRECTORIES)
 
   target_include_directories(${target} PRIVATE
       ${PROJECT_SOURCE_DIR}/test/common
       ${PROJECT_SOURCE_DIR}/test/bench/utils
-      ${SYCLFFT_INCLUDES}
+      ${PORTFFT_INCLUDES}
   )
-  if(SYCLFFT_VERIFY_BENCHMARK)
-      target_compile_definitions(${target} PRIVATE PORTFFT_VERIFY_BENCHMARK)
+  if(PORTFFT_VERIFY_BENCHMARKS)
+      target_compile_definitions(${target} PRIVATE PORTFFT_VERIFY_BENCHMARKS)
       target_include_directories(${target} PRIVATE ${BENCHMARK_REFERENCE_DATA_HEADER_DIR})
       add_dependencies(${target} benchmark_reference_data_header)
-      if(SYCLFFT_GENERATE_BENCH_REFERENCE_AT_BUILD_TIME)
+      if(PORTFFT_GENERATE_BENCH_REFERENCE_AT_BUILD_TIME)
         add_dependencies(${target} benchmark_reference_data_data)
       endif()
   endif()

--- a/test/bench/portfft/launch_bench.hpp
+++ b/test/bench/portfft/launch_bench.hpp
@@ -64,24 +64,24 @@ void bench_dft_average_host_time_impl(benchmark::State& state, sycl::queue q, po
   auto committed = desc.commit(q);
   q.wait();
 
-#ifdef PORTFFT_VERIFY_BENCHMARK
+#ifdef PORTFFT_VERIFY_BENCHMARKS
   auto verifSpec = get_matching_spec(verification_data, desc);
   auto host_input = verifSpec.load_data_time(desc);
   q.copy(host_input.data(), in_dev, num_elements).wait();
-#endif  // PORTFFT_VERIFY_BENCHMARK
+#endif  // PORTFFT_VERIFY_BENCHMARKS
 
   // warmup
   auto event = desc.placement == portfft::placement::IN_PLACE ? committed.compute_forward(in_dev)
                                                               : committed.compute_forward(in_dev, out_dev);
   event.wait();
 
-#ifdef PORTFFT_VERIFY_BENCHMARK
+#ifdef PORTFFT_VERIFY_BENCHMARKS
   std::vector<complex_type> host_output(num_elements);
   q.copy(desc.placement == portfft::placement::IN_PLACE ? reinterpret_cast<complex_type*>(in_dev) : out_dev,
          host_output.data(), num_elements)
       .wait();
   verifSpec.verify_dft(desc, host_output, portfft::direction::FORWARD, 1e-2);
-#endif  // PORTFFT_VERIFY_BENCHMARK
+#endif  // PORTFFT_VERIFY_BENCHMARKS
   std::vector<sycl::event> dependencies;
   dependencies.reserve(1);
 
@@ -164,11 +164,11 @@ void bench_dft_device_time_impl(benchmark::State& state, sycl::queue q, portfft:
   auto committed = desc.commit(q);
 
   q.wait();
-#ifdef PORTFFT_VERIFY_BENCHMARK
+#ifdef PORTFFT_VERIFY_BENCHMARKS
   auto verifSpec = get_matching_spec(verification_data, desc);
   auto host_input = verifSpec.load_data_time(desc);
   q.copy(host_input.data(), in_dev, num_elements).wait();
-#endif  // PORTFFT_VERIFY_BENCHMARK
+#endif  // PORTFFT_VERIFY_BENCHMARKS
 
   auto compute = [&]() {
     return desc.placement == portfft::placement::IN_PLACE ? committed.compute_forward(in_dev)
@@ -177,13 +177,13 @@ void bench_dft_device_time_impl(benchmark::State& state, sycl::queue q, portfft:
   // warmup
   compute().wait();
 
-#ifdef PORTFFT_VERIFY_BENCHMARK
+#ifdef PORTFFT_VERIFY_BENCHMARKS
   std::vector<complex_type> host_output(num_elements);
   q.copy(desc.placement == portfft::placement::IN_PLACE ? reinterpret_cast<complex_type*>(in_dev) : out_dev,
          host_output.data(), num_elements)
       .wait();
   verifSpec.verify_dft(desc, host_output, portfft::direction::FORWARD, 1e-2);
-#endif  // PORTFFT_VERIFY_BENCHMARK
+#endif  // PORTFFT_VERIFY_BENCHMARKS
 
   for (auto _ : state) {
     sycl::event e = compute();

--- a/test/bench/utils/bench_utils.hpp
+++ b/test/bench/utils/bench_utils.hpp
@@ -31,11 +31,11 @@
 
 #include "enums.hpp"
 
-#ifdef PORTFFT_VERIFY_BENCHMARK
+#ifdef PORTFFT_VERIFY_BENCHMARKS
 // The following file in generated during the build and located at
 // ${BUILD_DIR}/ref_data_include/
 #include <benchmark_reference.hpp>
-#endif  // PORTFFT_VERIFY_BENCHMARK
+#endif  // PORTFFT_VERIFY_BENCHMARKS
 
 /**
  * number of runs to do when doing an average of many host runs.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -35,12 +35,12 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-set(SYCLFFT_UNIT_TESTS
+set(PORTFFT_UNIT_TESTS
     fft_float.cpp
     transfers.cpp
 )
-if(SYCLFFT_ENABLE_DOUBLE_BUILDS)
-    list(APPEND SYCLFFT_UNIT_TESTS
+if(PORTFFT_ENABLE_DOUBLE_BUILDS)
+    list(APPEND PORTFFT_UNIT_TESTS
         fft_double.cpp
     )
 endif()
@@ -68,7 +68,7 @@ add_custom_target(test_reference_data_data
     DEPENDS ${TEST_REFERENCE_DATA_DATA_FILES})
 
 include(GoogleTest)
-foreach(UNIT_TEST_FILE ${SYCLFFT_UNIT_TESTS})
+foreach(UNIT_TEST_FILE ${PORTFFT_UNIT_TESTS})
     get_filename_component(FILE_NAME ${UNIT_TEST_FILE} NAME_WE)
     set(TEST_TARGET "test_${FILE_NAME}")
     add_executable(


### PR DESCRIPTION
* Renames for SYCL-FFT -> portFFT renaming.
* Also improves on some names whilst we're at it.

## Checklist

Tick if relevant:

* [N/A ] New files have a copyright
* [N/A ] New headers have an include guards
* [N/A ] API is documented with Doxygen
* N/A[ ] New functionalities are tested
* [x ] Tests pass locally
* [x ] Files are clang-formatted
