### PR TITLE
Remove 2D and 3D cases from benchmark reference set

### DIFF
--- a/scripts/benchmark_reference_specification.py
+++ b/scripts/benchmark_reference_specification.py
@@ -78,47 +78,33 @@ def make_data_spec(file_base):
             "input_dimensions": [64 * 1024 + 1],
             "batch": 2 * 1024,
         },
-        # 6. large complex 2D fits in global memory
+        # 6. small real 1D fits in workitem Cooley-Tukey
         {
             "file_path": make_path("benchmark_6.dat"),
-            "transform_type": "COMPLEX",
-            "input_dimensions": [4096, 4096],
-            "batch": 8,
-        },
-        # 7. small real 1D fits in workitem Cooley-Tukey
-        {
-            "file_path": make_path("benchmark_7.dat"),
             "transform_type": "REAL",
             "input_dimensions": [32],
             "batch": 8 * 1024 * 1024,
         },
-        # 8. medium-small real 1D fits in subgroup Cooley-Tukey
+        # 7. medium-small real 1D fits in subgroup Cooley-Tukey
         {
-            "file_path": make_path("benchmark_8.dat"),
+            "file_path": make_path("benchmark_7.dat"),
             "transform_type": "REAL",
             "input_dimensions": [512],
             "batch": 512 * 1024,
         },
-        # 9. medium-large real 1D fits in local memory Cooley-Tukey
+        # 8. medium-large real 1D fits in local memory Cooley-Tukey
         {
-            "file_path": make_path("benchmark_9.dat"),
+            "file_path": make_path("benchmark_8.dat"),
             "transform_type": "REAL",
             "input_dimensions": [8 * 1024],
             "batch": 32 * 1024,
         },
-        # 10. large real 1D fits in global memory Cooley-Tukey
+        # 9. large real 1D fits in global memory Cooley-Tukey
         {
-            "file_path": make_path("benchmark_10.dat"),
+            "file_path": make_path("benchmark_9.dat"),
             "transform_type": "REAL",
             "input_dimensions": [128 * 1024],
             "batch": 2 * 1024,
         },
-        # 11. small real 3D
-        {
-            "file_path": make_path("benchmark_11.dat"),
-            "transform_type": "REAL",
-            "input_dimensions": [64, 64, 64],
-            "batch": 1024,
-        }
     ]
     return cases

--- a/test/bench/utils/reference_dft_set.hpp
+++ b/test/bench/utils/reference_dft_set.hpp
@@ -41,14 +41,12 @@
 // 3. medium-large complex 1D fits in local memory Cooley-Tukey    (batch=32*1024     N=4*1024)
 // 4. large        complex 1D fits in global memory Cooley-Tukey   (batch=2*1024      N=64*1024)
 // 5. large        complex 1D fits in global memory Bluestein      (batch=2*1024      N=64*1024+1)
-// 6. large        complex 2D fits in global memory                (batch=8           N=4096x4096)
-// 7. small        real    1D fits in workitem Cooley-Tukey        (batch=8*1024*1024 N=32)
-// 8. medium-small real    1D fits in subgroup Cooley-Tukey        (batch=512*1024    N=512)
-// 9. medium-large real    1D fits in local memory Cooley-Tukey    (batch=32*1024     N=8*1024)
-// 10. large       real    1D fits in global memory Cooley-Tukey   (batch=2*1024      N=128*1024)
-// 11. small       real    3D                                      (batch=1024        N=64x64x64)
+// 6. small        real    1D fits in workitem Cooley-Tukey        (batch=8*1024*1024 N=32)
+// 7. medium-small real    1D fits in subgroup Cooley-Tukey        (batch=512*1024    N=512)
+// 8. medium-large real    1D fits in local memory Cooley-Tukey    (batch=32*1024     N=8*1024)
+// 9. large        real    1D fits in global memory Cooley-Tukey   (batch=2*1024      N=128*1024)
 //
-// Configurations must match with the ones in test/bench/portfft/launch_bench.hpp
+// Configurations must match with the ones in test/bench/portfft/bench_float.cpp
 // clang-format on
 
 /**
@@ -93,7 +91,6 @@ void register_complex_float_benchmark_set(std::string prefix, Args&&... args) {
   register_benchmark<Args...>(prefix, "medium_large_1d", args..., {4 * 1024},      32 * 1024);
   register_benchmark<Args...>(prefix, "large_1d",        args..., {64 * 1024},     2 * 1024);
   register_benchmark<Args...>(prefix, "large_1d_prime",  args..., {64 * 1024 + 1}, 2 * 1024);
-  register_benchmark<Args...>(prefix, "large_2d",        args..., {4096, 4096},    8);
   // clang-format on
 }
 
@@ -112,7 +109,6 @@ void register_real_float_benchmark_set(std::string prefix, Args&&... args) {
   register_benchmark<Args...>(prefix, "medium_small_1d", args..., {512},        512 * 1024);
   register_benchmark<Args...>(prefix, "medium_large_1d", args..., {8 * 1024},   32 * 1024);
   register_benchmark<Args...>(prefix, "large_1d",        args..., {128 * 1024}, 2 * 1024);
-  register_benchmark<Args...>(prefix, "small_3d",        args..., {64, 64, 64}, 1024);
   // clang-format on
 }
 


### PR DESCRIPTION
* 2D and 3D cases are no longer wanted in benchmark reference set.
* Removes mentions of these cases.

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [x] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
