### PR TITLE
Increase minimum cmake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 # *
 # **************************************************************************/
 
-cmake_minimum_required(VERSION 3.16...3.26)
+cmake_minimum_required(VERSION 3.20...3.26)
 project(portFFT VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ portFFT is in early stages of development and will support more options and opti
   * Other SYCL implementations are not tested
 * [Level Zero] drivers
   * OpenCL drivers are not supported
-* CMake 3.16+
+* CMake 3.20+
 * For tests and verifying benchmarks:
   * Python
   * Numpy


### PR DESCRIPTION
Increases the minimum cmake version and should update all references to that minimum version.

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [N/A] New functionalities are tested
* [N/A] Tests pass locally
* [N/A] Files are clang-formatted
