### PR TITLE
Fix build with Clang

### DIFF
--- a/src/portfft/common/global.hpp
+++ b/src/portfft/common/global.hpp
@@ -360,8 +360,6 @@ static void dispatch_transpose_kernel_impl(const Scalar* input, Scalar* output, 
       });
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wintel-compat"
 /**
  * Prepares the launch of transposition at a particular level
  * @tparam Scalar Scalar type
@@ -523,7 +521,6 @@ std::vector<sycl::event> compute_level(
   }
   return events;
 }
-#pragma clang diagnostic pop
 }  // namespace detail
 }  // namespace portfft
 

--- a/src/portfft/descriptor.hpp
+++ b/src/portfft/descriptor.hpp
@@ -179,18 +179,18 @@ class committed_descriptor {
   template <typename Scalar1, domain Domain1, direction Dir, detail::layout LayoutIn, detail::layout LayoutOut,
             Idx SubgroupSize, typename TIn>
   friend std::vector<sycl::event> detail::compute_level(
-      const typename committed_descriptor<Scalar1, Domain1>::kernel_data_struct& kd_struct, TIn input, Scalar* output,
-      const Scalar* twiddles_ptr, const IdxGlobal* factors_triple, Scalar scale_factor,
+      const typename committed_descriptor<Scalar1, Domain1>::kernel_data_struct& kd_struct, TIn input, Scalar1* output,
+      const Scalar1* twiddles_ptr, const IdxGlobal* factors_triple, Scalar1 scale_factor,
       IdxGlobal intermediate_twiddle_offset, IdxGlobal subimpl_twiddle_offset, IdxGlobal input_global_offset,
       IdxGlobal committed_size, Idx num_batches_in_l2, IdxGlobal n_transforms, IdxGlobal batch_start, Idx factor_id,
       Idx total_factors, const std::vector<sycl::event>& dependencies, sycl::queue& queue);
 
   template <typename Scalar1, domain Domain1, typename TOut>
   friend sycl::event detail::transpose_level(
-      const typename committed_descriptor<Scalar1, Domain1>::kernel_data_struct& kd_struct, const Scalar* input,
+      const typename committed_descriptor<Scalar1, Domain1>::kernel_data_struct& kd_struct, const Scalar1* input,
       TOut output, const IdxGlobal* factors_triple, IdxGlobal committed_size, Idx num_batches_in_l2,
       IdxGlobal n_transforms, IdxGlobal batch_start, Idx factor_num, Idx total_factors, IdxGlobal output_offset,
-      sycl::queue& queue, std::shared_ptr<Scalar>& ptr1, std::shared_ptr<Scalar>& ptr2,
+      sycl::queue& queue, std::shared_ptr<Scalar1>& ptr1, std::shared_ptr<Scalar1>& ptr2,
       const std::vector<sycl::event>& events);
 
   descriptor<Scalar, Domain> params;

--- a/src/portfft/dispatcher/global_dispatcher.hpp
+++ b/src/portfft/dispatcher/global_dispatcher.hpp
@@ -309,7 +309,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
                                         detail::layout::BATCH_INTERLEAVED, SubgroupSize>(
           desc.dimensions.at(0).kernels.at(0), in, desc.scratch_ptr_1.get(), twiddles_ptr, factors_and_scan,
           scale_factor, intermediate_twiddles_offset, impl_twiddle_offset,
-          2 * static_cast<IdxGlobal>(i) * committed_size + 2 * input_offset, committed_size,
+          2 * static_cast<IdxGlobal>(i) * committed_size + input_offset, committed_size,
           static_cast<Idx>(max_batches_in_l2), static_cast<IdxGlobal>(num_batches), static_cast<IdxGlobal>(i), 0,
           desc.dimensions.at(0).num_factors, {event}, desc.queue);
       intermediate_twiddles_offset += 2 * desc.dimensions.at(0).kernels.at(0).batch_size *
@@ -358,7 +358,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
           desc.dimensions.at(0).kernels.at(static_cast<std::size_t>(num_factors)),
           static_cast<const Scalar*>(desc.scratch_ptr_1.get()), out, factors_and_scan, committed_size,
           static_cast<Idx>(max_batches_in_l2), n_transforms, static_cast<IdxGlobal>(i), 0, num_factors,
-          2 * static_cast<IdxGlobal>(i) * committed_size + 2 * output_offset, desc.queue, desc.scratch_ptr_1,
+          2 * static_cast<IdxGlobal>(i) * committed_size + output_offset, desc.queue, desc.scratch_ptr_1,
           desc.scratch_ptr_2, {event});
     }
     return event;


### PR DESCRIPTION
<!-- Add short PR description here -->
Fixes compilation issues with nightly dpcpp and the clang shipped with oneapi toolkit. Removes the pragma to ignore -Wintel-compat.
Also fixes the bug in offset test in global FFTs introduced in #115 
## Checklist

Tick if relevant:

* [NA] New files have a copyright
* [NA] New headers have an include guards
* [NA] API is documented with Doxygen
* [NA] New functionalities are tested
* [X] Tests pass locally
* [X] Files are clang-formatted
