### PR TITLE
Bump DPCPP to 2024.0 release

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,23 @@
 ---
-Checks:          'readability-*,-readability-identifier-length,-readability-function-cognitive-complexity,-readability-named-parameter,performance-*,bugprone-*,-bugprone-standalone-empty,-bugprone-easily-swappable-parameters,-bugprone-implicit-widening-of-multiplication-result,misc-*,-misc-const-correctness,-misc-non-private-member-variables-in-classes,modernize-type-traits,modernize-use-using,llvm-include-order'
+Checks: >
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-standalone-empty,
+  llvm-include-order,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-non-private-member-variables-in-classes,
+  modernize-type-traits,
+  modernize-use-using,
+  performance-*,
+  -performance-avoid-endl,
+  readability-*,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-named-parameter,
+
 WarningsAsErrors: true
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Clone portFFT and run the following commands from the cloned repository.
 Build using DPC++ 2024.0 as:
 
 ```shell
-source /opt/intel/oneapi/compiler/2024.0/env/vars.sh
-cmake -Bbuild -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2024.0/linux/bin/icpx -DPORTFFT_BUILD_TESTS=ON -DPORTFFT_BUILD_BENCHMARKS=ON
+source /path/to/intel/oneapi/compiler/2024.0/env/vars.sh
+cmake -Bbuild -DCMAKE_CXX_COMPILER=icpx -DPORTFFT_BUILD_TESTS=ON -DPORTFFT_BUILD_BENCHMARKS=ON
 cmake --build build
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ portFFT is in early stages of development and will support more options and opti
 
 ## Pre-requisites
 
-* [DPC++] oneAPI release 2023.2.0
+* [DPC++] oneAPI release 2024.0
   * Nightly releases from [intel/llvm] should work but are not tested
   * Other SYCL implementations are not tested
 * [Level Zero] drivers
@@ -23,11 +23,11 @@ portFFT is in early stages of development and will support more options and opti
 
 Clone portFFT and run the following commands from the cloned repository.
 
-Build using DPC++ 2023.2.0 as:
+Build using DPC++ 2024.0 as:
 
 ```shell
-source /opt/intel/oneapi/compiler/2023.2.0/env/vars.sh
-cmake -Bbuild -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2023.2.0/linux/bin/icpx -DPORTFFT_BUILD_TESTS=ON -DPORTFFT_BUILD_BENCHMARKS=ON
+source /opt/intel/oneapi/compiler/2024.0/env/vars.sh
+cmake -Bbuild -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2024.0/linux/bin/icpx -DPORTFFT_BUILD_TESTS=ON -DPORTFFT_BUILD_BENCHMARKS=ON
 cmake --build build
 ```
 

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -27,7 +27,7 @@
 include_guard()
 
 # Try to find a DPC++ release
-# (reqrs source /opt/intel/oneapi/compilers/2024.0/env/vars.sh)
+# (reqrs source /path/to/intel/oneapi/compiler/2024.0/env/vars.sh)
 find_package(IntelSYCL QUIET)
 if(IntelSYCL_FOUND)
     function(add_sycl_to_target)

--- a/cmake/Modules/FindSYCL.cmake
+++ b/cmake/Modules/FindSYCL.cmake
@@ -27,7 +27,7 @@
 include_guard()
 
 # Try to find a DPC++ release
-# (reqrs source /opt/intel/oneapi/compilers/2023.2.0/env/vars.sh)
+# (reqrs source /opt/intel/oneapi/compilers/2024.0/env/vars.sh)
 find_package(IntelSYCL QUIET)
 if(IntelSYCL_FOUND)
     function(add_sycl_to_target)

--- a/src/portfft/common/helpers.hpp
+++ b/src/portfft/common/helpers.hpp
@@ -72,7 +72,6 @@ inline T round_up_to_multiple(T value, T factor) {
 
 /**
  * Cast a raw pointer to a global sycl::multi_ptr.
- * The multi_ptr is using the legacy decoration for now as this is better supported.
  *
  * @tparam T Pointer type
  * @param ptr Raw pointer to cast to multi_ptr
@@ -80,12 +79,11 @@ inline T round_up_to_multiple(T value, T factor) {
  */
 template <typename T>
 inline auto get_global_multi_ptr(T ptr) {
-  return sycl::address_space_cast<sycl::access::address_space::global_space, sycl::access::decorated::legacy>(ptr);
+  return sycl::address_space_cast<sycl::access::address_space::global_space, sycl::access::decorated::yes>(ptr);
 }
 
 /**
  * Cast a raw pointer to a local sycl::multi_ptr.
- * The multi_ptr is using the legacy decoration for now as this is better supported.
  *
  * @tparam T Pointer type
  * @param ptr Raw pointer to cast to multi_ptr
@@ -93,7 +91,7 @@ inline auto get_global_multi_ptr(T ptr) {
  */
 template <typename T>
 inline auto get_local_multi_ptr(T ptr) {
-  return sycl::address_space_cast<sycl::access::address_space::local_space, sycl::access::decorated::legacy>(ptr);
+  return sycl::address_space_cast<sycl::access::address_space::local_space, sycl::access::decorated::yes>(ptr);
 }
 
 /**
@@ -119,7 +117,7 @@ T* get_access(T* ptr, sycl::handler&) {
  */
 template <typename T>
 auto get_access(sycl::buffer<T, 1> buf, sycl::handler& cgh) {
-  if constexpr (std::is_const<T>::value) {
+  if constexpr (std::is_const_v<T>) {
     return buf.template get_access<sycl::access::mode::read>(cgh);
   } else {
     return buf.template get_access<sycl::access::mode::write>(cgh);

--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -609,7 +609,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
                              const std::vector<sycl::event>& dependencies, IdxGlobal n_transforms,
                              IdxGlobal input_offset, IdxGlobal output_offset, Scalar scale_factor,
                              dimension_struct& dimension_data) {
-    constexpr detail::memory Mem = std::is_pointer<TOut>::value ? detail::memory::USM : detail::memory::BUFFER;
+    constexpr detail::memory Mem = std::is_pointer_v<TOut> ? detail::memory::USM : detail::memory::BUFFER;
     auto& kernel_data = dimension_data.kernels.at(0);
     Scalar* twiddles = kernel_data.twiddles_forward.get();
     Idx factor_sg = kernel_data.factors[1];

--- a/src/portfft/dispatcher/workgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/workgroup_dispatcher.hpp
@@ -220,7 +220,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
         return 1;
       }
     }();
-    constexpr detail::memory Mem = std::is_pointer<TOut>::value ? detail::memory::USM : detail::memory::BUFFER;
+    constexpr detail::memory Mem = std::is_pointer_v<TOut> ? detail::memory::USM : detail::memory::BUFFER;
     Scalar* twiddles = kernel_data.twiddles_forward.get();
     std::size_t local_elements =
         num_scalars_in_local_mem_struct::template inner<detail::level::WORKGROUP, LayoutIn, Dummy>::execute(

--- a/src/portfft/dispatcher/workitem_dispatcher.hpp
+++ b/src/portfft/dispatcher/workitem_dispatcher.hpp
@@ -281,7 +281,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
                              const std::vector<sycl::event>& dependencies, IdxGlobal n_transforms,
                              IdxGlobal input_offset, IdxGlobal output_offset, Scalar scale_factor,
                              dimension_struct& dimension_data) {
-    constexpr detail::memory Mem = std::is_pointer<TOut>::value ? detail::memory::USM : detail::memory::BUFFER;
+    constexpr detail::memory Mem = std::is_pointer_v<TOut> ? detail::memory::USM : detail::memory::BUFFER;
     auto& kernel_data = dimension_data.kernels.at(0);
     std::size_t local_elements =
         num_scalars_in_local_mem_struct::template inner<detail::level::WORKITEM, LayoutIn, Dummy>::execute(

--- a/test/clang_tidy/CMakeLists.txt
+++ b/test/clang_tidy/CMakeLists.txt
@@ -36,7 +36,12 @@ target_link_libraries(
 
 # setup clang-tidy command from executable + options
 get_filename_component(CXX_COMPILER_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
-set(CLANG_TIDY_COMMAND "${CXX_COMPILER_DIR}/../bin-llvm/clang-tidy;--header-filter=${CMAKE_SOURCE_DIR}/src/*;--config-file=${CMAKE_SOURCE_DIR}/.clang-tidy")
+find_program(CLANG_TIDY_BIN clang-tidy
+  PATHS ${CXX_COMPILER_DIR}
+  PATH_SUFFIXES compiler
+  REQUIRED
+)
+set(CLANG_TIDY_COMMAND "${CLANG_TIDY_BIN};--header-filter=${CMAKE_SOURCE_DIR}/src/*;--config-file=${CMAKE_SOURCE_DIR}/.clang-tidy")
 if(PORTFFT_CLANG_TIDY_AUTOFIX)
     list(APPEND CLANG_TIDY_COMMAND "--fix")
 endif()


### PR DESCRIPTION
* Fix warnings when building with DPCPP 2024.0.
* Fix path to clang-tidy which moved with oneapi 2024.0. Using more modern `find_program`.
* Split clang-tidy checks on multiple lines for a better diff in the future.
  * Added `-performance-avoid-endl`. I think it's fair to use `std::endl` to flush before we throw exceptions.
  * Added `-misc-include-cleaner`. This gives warnings when we include "global headers" that include multiple headers, see below:
```
/home/romain/prog/portfft/build/../test/clang_tidy/clang_tidy_dummy.cpp:21:1: warning: included header sycl.hpp is not used directly [misc-include-cleaner]
   21 | #include <sycl/sycl.hpp>
      | ^~~~~~~~~~~~~~~~~~~~~~~~
   22 | 
/home/romain/prog/portfft/build/../test/clang_tidy/clang_tidy_dummy.cpp:23:1: warning: included header portfft.hpp is not used directly [misc-include-cleaner]
   23 | #include <portfft/portfft.hpp>
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   24 | 
/home/romain/prog/portfft/build/../test/clang_tidy/clang_tidy_dummy.cpp:26:12: warning: no header providing "portfft::descriptor" is directly included [misc-include-cleaner]
   21 | #include <sycl/sycl.hpp>
   22 | 
   23 | #include <portfft/portfft.hpp>
   24 | 
   25 | int main() {
   26 |   portfft::descriptor<float, portfft::domain::COMPLEX> desc{{2}};
      |            ^
/home/romain/prog/portfft/build/../test/clang_tidy/clang_tidy_dummy.cpp:26:39: warning: no header providing "portfft::domain" is directly included [misc-include-cleaner]
   21 | #include <sycl/sycl.hpp>
   22 | 
   23 | #include <portfft/portfft.hpp>
   24 | 
   25 | int main() {
   26 |   portfft::descriptor<float, portfft::domain::COMPLEX> desc{{2}};
      |                                       ^
/home/romain/prog/portfft/build/../test/clang_tidy/clang_tidy_dummy.cpp:26:47: warning: no header providing "portfft::domain::COMPLEX" is directly included [misc-include-cleaner]
   21 | #include <sycl/sycl.hpp>
   22 | 
   23 | #include <portfft/portfft.hpp>
   24 | 
   25 | int main() {
   26 |   portfft::descriptor<float, portfft::domain::COMPLEX> desc{{2}};
      |                                               ^
```

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [N/A] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
