### PR TITLE
Introduce PORTFFT_REQD_SUBGROUP_SIZE macro

### DIFF
--- a/src/portfft/common/global.hpp
+++ b/src/portfft/common/global.hpp
@@ -204,7 +204,7 @@ void launch_kernel(sycl::accessor<const Scalar, 1, sycl::access::mode::read>& in
 #endif
   cgh.parallel_for<global_kernel<Scalar, Domain, Dir, memory::BUFFER, LayoutIn, LayoutOut, SubgroupSize>>(
       sycl::nd_range<1>(global_range, local_range),
-      [=](sycl::nd_item<1> it, sycl::kernel_handler kh) [[sycl::reqd_sub_group_size(SubgroupSize)]] {
+      [=](sycl::nd_item<1> it, sycl::kernel_handler kh) PORTFFT_REQD_SUBGROUP_SIZE(SubgroupSize) {
         detail::global_data_struct global_data{
 #ifdef PORTFFT_LOG
             s,
@@ -257,7 +257,7 @@ void launch_kernel(const Scalar* input, Scalar* output, sycl::local_accessor<Sca
   auto [global_range, local_range] = launch_params;
   cgh.parallel_for<global_kernel<Scalar, Domain, Dir, memory::USM, LayoutIn, LayoutOut, SubgroupSize>>(
       sycl::nd_range<1>(global_range, local_range),
-      [=](sycl::nd_item<1> it, sycl::kernel_handler kh) [[sycl::reqd_sub_group_size(SubgroupSize)]] {
+      [=](sycl::nd_item<1> it, sycl::kernel_handler kh) PORTFFT_REQD_SUBGROUP_SIZE(SubgroupSize) {
         detail::global_data_struct global_data{
 #ifdef PORTFFT_LOG
             s,

--- a/src/portfft/defines.hpp
+++ b/src/portfft/defines.hpp
@@ -37,6 +37,8 @@
 #define PORTFFT_UNROLL _Pragma("clang loop unroll(full)")
 #endif
 
+#define PORTFFT_REQD_SUBGROUP_SIZE(SIZE) [[sycl::reqd_sub_group_size(SIZE)]]
+
 static_assert((PORTFFT_VEC_LOAD_BYTES & (PORTFFT_VEC_LOAD_BYTES - 1)) == 0,
               "PORTFFT_VEC_LOAD_BYTES should be a power of 2!");
 

--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -633,7 +633,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
 #endif
       cgh.parallel_for<detail::subgroup_kernel<Scalar, Domain, Dir, Mem, LayoutIn, LayoutOut, SubgroupSize>>(
           sycl::nd_range<1>{{global_size}, {static_cast<std::size_t>(SubgroupSize * kernel_data.num_sgs_per_wg)}},
-          [=](sycl::nd_item<1> it, sycl::kernel_handler kh) [[sycl::reqd_sub_group_size(SubgroupSize)]] {
+          [=](sycl::nd_item<1> it, sycl::kernel_handler kh) PORTFFT_REQD_SUBGROUP_SIZE(SubgroupSize) {
             detail::global_data_struct global_data{
 #ifdef PORTFFT_LOG
                 s,

--- a/src/portfft/dispatcher/workgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/workgroup_dispatcher.hpp
@@ -244,7 +244,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
 #endif
       cgh.parallel_for<detail::workgroup_kernel<Scalar, Domain, Dir, Mem, LayoutIn, LayoutOut, SubgroupSize>>(
           sycl::nd_range<1>{{global_size}, {static_cast<std::size_t>(SubgroupSize * PORTFFT_SGS_IN_WG)}},
-          [=](sycl::nd_item<1> it, sycl::kernel_handler kh) [[sycl::reqd_sub_group_size(SubgroupSize)]] {
+          [=](sycl::nd_item<1> it, sycl::kernel_handler kh) PORTFFT_REQD_SUBGROUP_SIZE(SubgroupSize) {
             detail::global_data_struct global_data{
 #ifdef PORTFFT_LOG
                 s,

--- a/src/portfft/dispatcher/workitem_dispatcher.hpp
+++ b/src/portfft/dispatcher/workitem_dispatcher.hpp
@@ -301,7 +301,7 @@ struct committed_descriptor<Scalar, Domain>::run_kernel_struct<Dir, LayoutIn, La
 #endif
       cgh.parallel_for<detail::workitem_kernel<Scalar, Domain, Dir, Mem, LayoutIn, LayoutOut, SubgroupSize>>(
           sycl::nd_range<1>{{global_size}, {static_cast<std::size_t>(SubgroupSize * kernel_data.num_sgs_per_wg)}},
-          [=](sycl::nd_item<1> it, sycl::kernel_handler kh) [[sycl::reqd_sub_group_size(SubgroupSize)]] {
+          [=](sycl::nd_item<1> it, sycl::kernel_handler kh) PORTFFT_REQD_SUBGROUP_SIZE(SubgroupSize) {
             detail::global_data_struct global_data{
 #ifdef PORTFFT_LOG
                 s,


### PR DESCRIPTION
The macro makes for better formatted code and avoids breaking `[=]` on multiple lines.
This is needed to enable GitHub clang-format check. See the check [before](https://github.com/Rbiessy/portFFT/pull/1/checks?check_run_id=19856978050) and [after](https://github.com/Rbiessy/portFFT/pull/1/checks?check_run_id=19857610596).

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [N/A] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
