### PR TITLE
Fix incorrect incorrect num_scalars_in_local_mem for subgroup impl

### DIFF
--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -668,8 +668,8 @@ struct committed_descriptor<Scalar, Domain>::num_scalars_in_local_mem_struct::in
   static std::size_t execute(committed_descriptor& desc, std::size_t length, Idx used_sg_size,
                              const std::vector<Idx>& factors, Idx& num_sgs_per_wg) {
     Idx dft_length = static_cast<Idx>(length);
+    Idx twiddle_bytes = 2 * dft_length * static_cast<Idx>(sizeof(Scalar));
     if constexpr (LayoutIn == detail::layout::BATCH_INTERLEAVED) {
-      Idx twiddle_bytes = 2 * dft_length * static_cast<Idx>(sizeof(Scalar));
       Idx padded_fft_bytes = detail::pad_local(2 * dft_length, Idx(1)) * static_cast<Idx>(sizeof(Scalar));
       Idx max_batches_in_local_mem = (desc.local_memory_size - twiddle_bytes) / padded_fft_bytes;
       Idx batches_per_sg = used_sg_size / 2;
@@ -682,7 +682,7 @@ struct committed_descriptor<Scalar, Domain>::num_scalars_in_local_mem_struct::in
       Idx factor_sg = factors[1];
       Idx n_ffts_per_sg = used_sg_size / factor_sg;
       Idx num_scalars_per_sg = detail::pad_local(2 * dft_length * n_ffts_per_sg, 1);
-      Idx max_n_sgs = desc.local_memory_size / static_cast<Idx>(sizeof(Scalar)) / num_scalars_per_sg;
+      Idx max_n_sgs = (desc.local_memory_size - twiddle_bytes) / static_cast<Idx>(sizeof(Scalar)) / num_scalars_per_sg;
       num_sgs_per_wg = std::min(Idx(PORTFFT_SGS_IN_WG), std::max(Idx(1), max_n_sgs));
       Idx res = num_scalars_per_sg * num_sgs_per_wg;
       return static_cast<std::size_t>(res);

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -54,6 +54,9 @@ constexpr test_placement_layouts_params valid_multi_dim_placement_layouts[] = {
     {placement::OUT_OF_PLACE, detail::layout::PACKED, detail::layout::PACKED}};
 auto all_valid_multi_dim_placement_layouts = ::testing::ValuesIn(valid_multi_dim_placement_layouts);
 
+auto ip_packed_layout = ::testing::Values(
+    test_placement_layouts_params{placement::IN_PLACE, detail::layout::PACKED, detail::layout::PACKED});
+
 auto oop_packed_layout = ::testing::Values(
     test_placement_layouts_params{placement::OUT_OF_PLACE, detail::layout::PACKED, detail::layout::PACKED});
 
@@ -94,6 +97,12 @@ INSTANTIATE_TEST_SUITE_P(SubgroupOrWorkgroupTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_placement_layouts, fwd_only, interleaved_storage, ::testing::Values(1, 131),
                              ::testing::Values(sizes_t{256}, sizes_t{512}, sizes_t{1024}))),
+                         test_params_print());
+// Regression test where subgroup or workgroup implemention depended on correct local memory requirement calcs.
+INSTANTIATE_TEST_SUITE_P(SubgroupOrWorkgroupRegressionTest, FFTTest,
+                         ::testing::ConvertGenerator<basic_param_tuple>(
+                             ::testing::Combine(ip_packed_layout, fwd_only, interleaved_storage, ::testing::Values(131),
+                                                ::testing::Values(sizes_t{1536}))),
                          test_params_print());
 // sizes that use workgroup implementation
 INSTANTIATE_TEST_SUITE_P(WorkgroupTest, FFTTest,


### PR DESCRIPTION
* Fixes bug on A100 where sub-group implementation is launched when there is not sufficient local memory.
* Add regression test.

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [x] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
