### PR TITLE
Ensure tests and benchmarks free USM pointers

### DIFF
--- a/test/bench/portfft/bench_float.cpp
+++ b/test/bench/portfft/bench_float.cpp
@@ -21,7 +21,7 @@
 #include <portfft/traits.hpp>
 
 #include "launch_bench.hpp"
-#include "utils/sycl_utils.hpp"
+#include "utils/device_context.hpp"
 
 template <typename T>
 void bench_dft(sycl::queue q, sycl::queue profiling_q, const std::string& suffix,
@@ -42,7 +42,7 @@ int main(int argc, char** argv) {
 
   sycl::queue q;
   sycl::queue profiling_q({sycl::property::queue::enable_profiling()});
-  print_device(q);
+  add_device_context(q);
 
   // Benchmark configurations must match with the ones in test/bench/utils/reference_dft_set.hpp
   // Configurations are progressively added as portFFT supports more of them.

--- a/test/bench/portfft/launch_bench.hpp
+++ b/test/bench/portfft/launch_bench.hpp
@@ -58,10 +58,8 @@ void bench_dft_average_host_time_impl(benchmark::State& state, sycl::queue q, po
   std::size_t bytes_transferred = global_mem_transactions<complex_type, complex_type>(N_transforms, N, N);
 
   auto in_dev = make_shared<forward_t>(num_elements, q);
-  std::shared_ptr<complex_type> out_dev;
-  if (desc.placement == portfft::placement::OUT_OF_PLACE) {
-    out_dev = make_shared<complex_type>(num_elements, q);
-  }
+  std::shared_ptr<complex_type> out_dev =
+      desc.placement == portfft::placement::OUT_OF_PLACE ? make_shared<complex_type>(num_elements, q) : nullptr;
 
   auto committed = desc.commit(q);
   q.wait();
@@ -160,10 +158,8 @@ void bench_dft_device_time_impl(benchmark::State& state, sycl::queue q, portfft:
   std::size_t bytes_transferred = global_mem_transactions<complex_type, complex_type>(N_transforms, N, N);
 
   auto in_dev = make_shared<forward_t>(num_elements, q);
-  std::shared_ptr<complex_type> out_dev;
-  if (desc.placement == portfft::placement::OUT_OF_PLACE) {
-    out_dev = make_shared<complex_type>(num_elements, q);
-  }
+  std::shared_ptr<complex_type> out_dev =
+      desc.placement == portfft::placement::OUT_OF_PLACE ? make_shared<complex_type>(num_elements, q) : nullptr;
 
   auto committed = desc.commit(q);
 

--- a/test/bench/portfft/register_manual_bench.hpp
+++ b/test/bench/portfft/register_manual_bench.hpp
@@ -31,7 +31,7 @@
 #include <utility>
 
 #include "launch_bench.hpp"
-#include "utils/sycl_utils.hpp"
+#include "utils/device_context.hpp"
 
 static constexpr std::pair<std::string_view, std::string_view> ARG_KEYS[] = {
     {"domain", "d"},    {"lengths", "n"},   {"batch", "b"},  {"fwd_strides", "fs"}, {"bwd_strides", "bs"},
@@ -308,7 +308,7 @@ int main_manual_bench(int argc, char** argv) {
 
   sycl::queue q;
   sycl::queue profiling_q({sycl::property::queue::enable_profiling()});
-  print_device(q);
+  add_device_context(q);
 
   for (int i = 1; i < argc; ++i) {
     std::string_view arg = argv[i];

--- a/test/bench/utils/device_context.hpp
+++ b/test/bench/utils/device_context.hpp
@@ -18,14 +18,14 @@
  *
  **************************************************************************/
 
-#ifndef PORTFFT_TEST_BENCH_UTILS_SYCL_UTILS_HPP
-#define PORTFFT_TEST_BENCH_UTILS_SYCL_UTILS_HPP
+#ifndef PORTFFT_TEST_BENCH_UTILS_DEVICE_CONTEXT_HPP
+#define PORTFFT_TEST_BENCH_UTILS_DEVICE_CONTEXT_HPP
 
 #include <sycl/sycl.hpp>
 
 #include <benchmark/benchmark.h>
 
-void print_device(sycl::queue queue) {
+void add_device_context(sycl::queue queue) {
   namespace info = sycl::info::device;
   using sycl::info::device_type;
   sycl::device dev = queue.get_device();
@@ -76,4 +76,4 @@ void print_device(sycl::queue queue) {
   benchmark::AddCustomContext("Subgroup sizes", subgroup_sizes_str.str());
 }
 
-#endif  // PORTFFT_TEST_BENCH_UTILS_SYCL_UTILS_HPP
+#endif  // PORTFFT_TEST_BENCH_UTILS_DEVICE_CONTEXT_HPP

--- a/test/common/sycl_utils.hpp
+++ b/test/common/sycl_utils.hpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Codeplay's portFFT
+ *
+ **************************************************************************/
+
+#ifndef PORTFFT_TEST_COMMON_SYCL_UTILS_HPP
+#define PORTFFT_TEST_COMMON_SYCL_UTILS_HPP
+
+#include <memory>
+
+#include <sycl/sycl.hpp>
+
+/**
+ * Utility function to create a shared pointer, with memory allocated on device
+ * @tparam T Type of the memory being allocated
+ * @param size Number of elements to allocate
+ * @param queue Associated queue
+ */
+template <typename T>
+inline std::shared_ptr<T> make_shared(std::size_t size, sycl::queue queue) {
+  return std::shared_ptr<T>(sycl::malloc_device<T>(size, queue), [captured_queue = queue](T* ptr) {
+    if (ptr != nullptr) {
+      sycl::free(ptr, captured_queue);
+    }
+  });
+}
+
+#endif  // PORTFFT_TEST_COMMON_SYCL_UTILS_HPP

--- a/test/unit_test/fft_test_utils.hpp
+++ b/test/unit_test/fft_test_utils.hpp
@@ -32,6 +32,7 @@
 
 #include "reference_data_wrangler.hpp"
 #include "sub_tuple.hpp"
+#include "sycl_utils.hpp"
 
 using namespace portfft;
 
@@ -233,25 +234,25 @@ std::enable_if_t<TestMemory == test_memory::usm> check_fft(
   auto committed_descriptor = desc.commit(queue);
 
   const bool is_oop = desc.placement == placement::OUT_OF_PLACE;
-  auto device_input = sycl::malloc_device<InputFType>(host_input.size(), queue);
-  OutputFType* device_output = nullptr;
-  RealFType* device_input_imag = nullptr;
-  RealFType* device_output_imag = nullptr;
+  auto device_input = make_shared<InputFType>(host_input.size(), queue);
+  std::shared_ptr<OutputFType> device_output;
+  std::shared_ptr<RealFType> device_input_imag;
+  std::shared_ptr<RealFType> device_output_imag;
   sycl::event oop_init_event;
   sycl::event oop_imag_init_event;
   sycl::event copy_event2;
 
-  auto copy_event = queue.copy(host_input.data(), device_input, host_input.size());
+  auto copy_event = queue.copy(host_input.data(), device_input.get(), host_input.size());
   if constexpr (Storage == complex_storage::SPLIT_COMPLEX) {
-    device_input_imag = sycl::malloc_device<RealFType>(host_input_imag.size(), queue);
-    copy_event2 = queue.copy(host_input_imag.data(), device_input_imag, host_input_imag.size());
+    device_input_imag = make_shared<RealFType>(host_input_imag.size(), queue);
+    copy_event2 = queue.copy(host_input_imag.data(), device_input_imag.get(), host_input_imag.size());
   }
   if (is_oop) {
-    device_output = sycl::malloc_device<OutputFType>(host_output.size(), queue);
-    oop_init_event = queue.copy(host_output.data(), device_output, host_output.size());
+    device_output = make_shared<OutputFType>(host_output.size(), queue);
+    oop_init_event = queue.copy(host_output.data(), device_output.get(), host_output.size());
     if constexpr (Storage == complex_storage::SPLIT_COMPLEX) {
-      device_output_imag = sycl::malloc_device<RealFType>(host_output_imag.size(), queue);
-      oop_imag_init_event = queue.copy(host_output_imag.data(), device_output_imag, host_output_imag.size());
+      device_output_imag = make_shared<RealFType>(host_output_imag.size(), queue);
+      oop_imag_init_event = queue.copy(host_output_imag.data(), device_output_imag.get(), host_output_imag.size());
     }
   }
 
@@ -261,56 +262,45 @@ std::enable_if_t<TestMemory == test_memory::usm> check_fft(
     if (is_oop) {
       if constexpr (Dir == direction::FORWARD) {
         if constexpr (Storage == complex_storage::INTERLEAVED_COMPLEX) {
-          return committed_descriptor.compute_forward(device_input, device_output, dependencies);
+          return committed_descriptor.compute_forward(device_input.get(), device_output.get(), dependencies);
         } else {
-          return committed_descriptor.compute_forward(device_input, device_input_imag, device_output,
-                                                      device_output_imag, dependencies);
+          return committed_descriptor.compute_forward(device_input.get(), device_input_imag.get(), device_output.get(),
+                                                      device_output_imag.get(), dependencies);
         }
       } else {
         if constexpr (Storage == complex_storage::INTERLEAVED_COMPLEX) {
-          return committed_descriptor.compute_backward(device_input, device_output, dependencies);
+          return committed_descriptor.compute_backward(device_input.get(), device_output.get(), dependencies);
         } else {
-          return committed_descriptor.compute_backward(device_input, device_input_imag, device_output,
-                                                       device_output_imag, dependencies);
+          return committed_descriptor.compute_backward(device_input.get(), device_input_imag.get(), device_output.get(),
+                                                       device_output_imag.get(), dependencies);
         }
       }
     } else {
       if constexpr (Dir == direction::FORWARD) {
         if constexpr (Storage == complex_storage::INTERLEAVED_COMPLEX) {
-          return committed_descriptor.compute_forward(device_input, dependencies);
+          return committed_descriptor.compute_forward(device_input.get(), dependencies);
         } else {
-          return committed_descriptor.compute_forward(device_input, device_input_imag, dependencies);
+          return committed_descriptor.compute_forward(device_input.get(), device_input_imag.get(), dependencies);
         }
       } else {
         if constexpr (Storage == complex_storage::INTERLEAVED_COMPLEX) {
-          return committed_descriptor.compute_backward(device_input, dependencies);
+          return committed_descriptor.compute_backward(device_input.get(), dependencies);
         } else {
-          return committed_descriptor.compute_backward(device_input, device_input_imag, dependencies);
+          return committed_descriptor.compute_backward(device_input.get(), device_input_imag.get(), dependencies);
         }
       }
     }
   }();
 
-  queue.copy(is_oop ? device_output : device_input, host_output.data(), host_output.size(), {fft_event});
+  queue.copy(is_oop ? device_output.get() : device_input.get(), host_output.data(), host_output.size(), {fft_event});
   if constexpr (Storage == complex_storage::SPLIT_COMPLEX) {
-    queue.copy(is_oop ? device_output_imag : device_input_imag, host_output_imag.data(), host_output_imag.size(),
-               {fft_event});
+    queue.copy(is_oop ? device_output_imag.get() : device_input_imag.get(), host_output_imag.data(),
+               host_output_imag.size(), {fft_event});
   }
   queue.wait_and_throw();
   verify_dft<Dir, Storage>(desc, host_reference_output, host_output, tolerance, "real");
   if constexpr (Storage == complex_storage::SPLIT_COMPLEX) {
     verify_dft<Dir, Storage>(desc, host_reference_output_imag, host_output_imag, tolerance, "imaginary");
-  }
-
-  sycl::free(device_input, queue);
-  if constexpr (Storage == complex_storage::SPLIT_COMPLEX) {
-    sycl::free(device_input_imag, queue);
-  }
-  if (is_oop) {
-    sycl::free(device_output, queue);
-    if constexpr (Storage == complex_storage::SPLIT_COMPLEX) {
-      sycl::free(device_output_imag, queue);
-    }
   }
 }
 

--- a/test/unit_test/transfers.cpp
+++ b/test/unit_test/transfers.cpp
@@ -48,11 +48,15 @@ void test() {
   }
 
   sycl::queue q;
-  ftype* sentinels_loc1_dev = sycl::malloc_device<ftype>(2 * N_sentinel_values, q);
-  ftype* sentinels_loc2_dev = sycl::malloc_device<ftype>(2 * N_sentinel_values, q);
+  auto sentinels_loc1_dev_sptr = make_shared<ftype>(2 * N_sentinel_values, q);
+  auto sentinels_loc2_dev_sptr = make_shared<ftype>(2 * N_sentinel_values, q);
+  ftype* sentinels_loc1_dev = sentinels_loc1_dev_sptr.get();
+  ftype* sentinels_loc2_dev = sentinels_loc2_dev_sptr.get();
 
-  ftype* a_dev = sycl::malloc_device<ftype>(N * wg_size + 2 * N_sentinel_values, q);
-  ftype* b_dev = sycl::malloc_device<ftype>(N * wg_size + 2 * N_sentinel_values, q);
+  auto a_dev_sptr = make_shared<ftype>(N * wg_size + 2 * N_sentinel_values, q);
+  auto b_dev_sptr = make_shared<ftype>(N * wg_size + 2 * N_sentinel_values, q);
+  ftype* a_dev = a_dev_sptr.get();
+  ftype* b_dev = b_dev_sptr.get();
   ftype* a_dev_work = a_dev + N_sentinel_values;
   ftype* b_dev_work = b_dev + N_sentinel_values;
 
@@ -134,10 +138,6 @@ void test() {
     EXPECT_EQ(loc1_sentinels[i], sentinel_loc1);
     EXPECT_EQ(loc2_sentinels[i], sentinel_loc2);
   }
-  sycl::free(a_dev, q);
-  sycl::free(b_dev, q);
-  sycl::free(sentinels_loc1_dev, q);
-  sycl::free(sentinels_loc2_dev, q);
 }
 
 TEST(transfers, unpadded) { test<portfft::detail::pad::DONT_PAD, 0>(); }


### PR DESCRIPTION
Use `shared_ptr` to ensure that USM pointers are free'd in tests and benchmarks even when they are skipped or failing.
This also renames `sycl_utils.hpp` -> `device_context.hpp` and `print_device` -> `add_device_context` to avoid some confusion with the new `sycl_utils.hpp` file.

## Checklist

Tick if relevant:

* [x] New files have a copyright
* [x] New headers have an include guards
* [x] API is documented with Doxygen
* [N/A] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
