### PR TITLE
Fix invalid USM pointer for opencl implementation

### DIFF
--- a/src/portfft/common/global.hpp
+++ b/src/portfft/common/global.hpp
@@ -509,6 +509,8 @@ std::vector<sycl::event> compute_level(
         // level cache.
         cgh.depends_on(dependencies.at(static_cast<std::size_t>(batch_in_l2)));
       }
+      // Backends may check pointer validity. For the WI implementation, where no subimpl_twiddles alloc is used,
+      // the subimpl_twiddles + subimpl_twiddle_offset may point to the end of the allocation and therefore be invalid.
       const bool using_wi_level = kd_struct.level == detail::level::WORKITEM;
       const Scalar* subimpl_twiddles = using_wi_level ? nullptr : twiddles_ptr + subimpl_twiddle_offset;
       detail::launch_kernel<Scalar, Dir, Domain, LayoutIn, LayoutOut, SubgroupSize>(

--- a/src/portfft/common/global.hpp
+++ b/src/portfft/common/global.hpp
@@ -509,11 +509,12 @@ std::vector<sycl::event> compute_level(
         // level cache.
         cgh.depends_on(dependencies.at(static_cast<std::size_t>(batch_in_l2)));
       }
+      const bool using_wi_level = kd_struct.level == detail::level::WORKITEM;
+      const Scalar* subimpl_twiddles = using_wi_level ? nullptr : twiddles_ptr + subimpl_twiddle_offset;
       detail::launch_kernel<Scalar, Dir, Domain, LayoutIn, LayoutOut, SubgroupSize>(
           in_acc_or_usm, output + 2 * batch_in_l2 * committed_size, loc_for_input, loc_for_twiddles, loc_for_modifier,
-          twiddles_ptr + intermediate_twiddle_offset, twiddles_ptr + subimpl_twiddle_offset, factors_triple,
-          inner_batches, inclusive_scan, batch_size, scale_factor,
-          2 * committed_size * batch_in_l2 + input_global_offset,
+          twiddles_ptr + intermediate_twiddle_offset, subimpl_twiddles, factors_triple, inner_batches, inclusive_scan,
+          batch_size, scale_factor, 2 * committed_size * batch_in_l2 + input_global_offset,
           {sycl::range<1>(static_cast<std::size_t>(global_range)),
            sycl::range<1>(static_cast<std::size_t>(local_range))},
           cgh);


### PR DESCRIPTION
* The OpenCL SYCL backend may fail with the global implementation due to an invalid pointer.
* The pointer is invalid because it is the end of an allocation, and consequently not a pointer to an allocation. The runtime appears to check this.
* In this state (encountered in work-item sub-implementation of Global), this pointer is not actually used.
* This checks if the pointer will be used, and sets it to nullptr if not, avoiding this issue.

<!-- Add short PR description here -->

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [N/A] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
