### PR TITLE
Add test to print device information

### DIFF
--- a/test/common/sycl_utils.hpp
+++ b/test/common/sycl_utils.hpp
@@ -22,6 +22,8 @@
 #define PORTFFT_TEST_COMMON_SYCL_UTILS_HPP
 
 #include <memory>
+#include <sstream>
+#include <string>
 
 #include <sycl/sycl.hpp>
 
@@ -38,6 +40,46 @@ inline std::shared_ptr<T> make_shared(std::size_t size, sycl::queue queue) {
       sycl::free(ptr, captured_queue);
     }
   });
+}
+
+/**
+ * Return the device type as a string
+ * @param dev SYCL device
+ */
+std::string get_device_type(sycl::device dev) {
+  using sycl::info::device_type;
+  switch (dev.get_info<sycl::info::device::device_type>()) {
+    case device_type::cpu:
+      return "CPU";
+    case device_type::gpu:
+      return "GPU";
+    case device_type::accelerator:
+      return "accelerator";
+    case device_type::custom:
+      return "custom";
+    case device_type::host:
+      return "host";
+    default:
+      return "unknown";
+  };
+}
+
+/**
+ * Return the list of supported subgroup sizes as a string
+ * @param dev SYCL device
+ */
+std::string get_device_subgroup_sizes(sycl::device dev) {
+  auto subgroup_sizes = dev.get_info<sycl::info::device::sub_group_sizes>();
+  std::stringstream subgroup_sizes_str;
+  subgroup_sizes_str << "[";
+  for (std::size_t i = 0; i < subgroup_sizes.size(); ++i) {
+    if (i > 0) {
+      subgroup_sizes_str << ", ";
+    }
+    subgroup_sizes_str << subgroup_sizes[i];
+  }
+  subgroup_sizes_str << "]";
+  return subgroup_sizes_str.str();
 }
 
 #endif  // PORTFFT_TEST_COMMON_SYCL_UTILS_HPP

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 set(PORTFFT_UNIT_TESTS
-    print_device.cpp
+    print_device_info.cpp
     descriptor.cpp
     transfers.cpp
     fft_float.cpp

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -36,9 +36,10 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 set(PORTFFT_UNIT_TESTS
-    fft_float.cpp
-    transfers.cpp
+    print_device.cpp
     descriptor.cpp
+    transfers.cpp
+    fft_float.cpp
 )
 if(PORTFFT_ENABLE_DOUBLE_BUILDS)
     list(APPEND PORTFFT_UNIT_TESTS

--- a/test/unit_test/fft_test_utils.hpp
+++ b/test/unit_test/fft_test_utils.hpp
@@ -392,18 +392,15 @@ std::enable_if_t<TestMemory == test_memory::buffer> check_fft(
  */
 template <test_memory TestMemory, typename FType, direction Dir, complex_storage Storage>
 void run_test(const test_params& params) {
-  std::vector<sycl::aspect> queue_aspects;
-  if constexpr (std::is_same_v<FType, double>) {
-    queue_aspects.push_back(sycl::aspect::fp64);
-  }
-  if constexpr (TestMemory == test_memory::usm) {
-    queue_aspects.push_back(sycl::aspect::usm_device_allocations);
-  }
+  // Use default selector to match with the device printed
   sycl::queue queue;
-  try {
-    queue = sycl::queue(sycl::aspect_selector(queue_aspects));
-  } catch (sycl::exception& e) {
-    GTEST_SKIP() << e.what();
+  sycl::device dev = queue.get_device();
+  if (std::is_same_v<FType, double> && !dev.has(sycl::aspect::fp64)) {
+    GTEST_SKIP() << "Device does not support double precision";
+    return;
+  }
+  if (TestMemory == test_memory::usm && !dev.has(sycl::aspect::usm_device_allocations)) {
+    GTEST_SKIP() << "Device does not support USM";
     return;
   }
 

--- a/test/unit_test/print_device.cpp
+++ b/test/unit_test/print_device.cpp
@@ -28,8 +28,7 @@
  */
 void print_device() {
   namespace info = sycl::info::device;
-  sycl::queue queue;
-  sycl::device dev = queue.get_device();
+  sycl::device dev;
   sycl::platform platform = dev.get_info<info::platform>();
 
   std::string device_type_str = get_device_type(dev);

--- a/test/unit_test/print_device.cpp
+++ b/test/unit_test/print_device.cpp
@@ -18,17 +18,17 @@
  *
  **************************************************************************/
 
-#ifndef PORTFFT_TEST_BENCH_UTILS_DEVICE_CONTEXT_HPP
-#define PORTFFT_TEST_BENCH_UTILS_DEVICE_CONTEXT_HPP
+#include <gtest/gtest.h>
 
-#include <sycl/sycl.hpp>
+#include "sycl_utils.hpp"
 
-#include <benchmark/benchmark.h>
-
-#include "common/sycl_utils.hpp"
-
-void add_device_context(sycl::queue queue) {
+/**
+ * Print information of the device selected by the default selector.
+ * Use this as a test to print the information once when using ctest.
+ */
+void print_device() {
   namespace info = sycl::info::device;
+  sycl::queue queue;
   sycl::device dev = queue.get_device();
   sycl::platform platform = dev.get_info<info::platform>();
 
@@ -36,18 +36,20 @@ void add_device_context(sycl::queue queue) {
   std::string supports_double_str = dev.has(sycl::aspect::fp64) ? "yes" : "no";
   std::string supports_usm_str = dev.has(sycl::aspect::usm_device_allocations) ? "yes" : "no";
   std::string subgroup_sizes_str = get_device_subgroup_sizes(dev);
-  std::string local_memory_size_str = std::to_string(dev.get_info<sycl::info::device::local_mem_size>()) + "B";
+  auto local_memory_size = dev.get_info<sycl::info::device::local_mem_size>();
 
-  benchmark::AddCustomContext("Device type", device_type_str);
-  benchmark::AddCustomContext("Platform", platform.get_info<sycl::info::platform::name>());
-  benchmark::AddCustomContext("Name", dev.get_info<info::name>());
-  benchmark::AddCustomContext("Vendor", dev.get_info<info::vendor>());
-  benchmark::AddCustomContext("Version", dev.get_info<info::version>());
-  benchmark::AddCustomContext("Driver version", dev.get_info<info::driver_version>());
-  benchmark::AddCustomContext("Double supported", supports_double_str);
-  benchmark::AddCustomContext("USM supported", supports_usm_str);
-  benchmark::AddCustomContext("Subgroup sizes", subgroup_sizes_str);
-  benchmark::AddCustomContext("Local memory size", local_memory_size_str);
+  std::cout << "Running tests on:\n";
+  std::cout << "  Device type: " << device_type_str << "\n";
+  std::cout << "  Platform: " << platform.get_info<sycl::info::platform::name>() << "\n";
+  std::cout << "  Name: " << dev.get_info<info::name>() << "\n";
+  std::cout << "  Vendor: " << dev.get_info<info::vendor>() << "\n";
+  std::cout << "  Version: " << dev.get_info<info::version>() << "\n";
+  std::cout << "  Driver version: " << dev.get_info<info::driver_version>() << "\n";
+  std::cout << "  Double supported: " << supports_double_str << "\n";
+  std::cout << "  USM supported: " << supports_usm_str << "\n";
+  std::cout << "  Subgroup sizes: " << subgroup_sizes_str << "\n";
+  std::cout << "  Local memory size: " << local_memory_size << "B\n";
+  std::cout << std::endl;
 }
 
-#endif  // PORTFFT_TEST_BENCH_UTILS_DEVICE_CONTEXT_HPP
+TEST(print_device, run) { print_device(); }

--- a/test/unit_test/print_device_info.cpp
+++ b/test/unit_test/print_device_info.cpp
@@ -26,7 +26,7 @@
  * Print information of the device selected by the default selector.
  * Use this as a test to print the information once when using ctest.
  */
-void print_device() {
+void print_device_info() {
   namespace info = sycl::info::device;
   sycl::device dev;
   sycl::platform platform = dev.get_info<info::platform>();
@@ -51,4 +51,4 @@ void print_device() {
   std::cout << std::endl;
 }
 
-TEST(print_device, run) { print_device(); }
+TEST(print_info, device) { print_device_info(); }


### PR DESCRIPTION
Add a test to print device information. This is the only solution I found to make this work while still using `ctest`.

## Checklist

Tick if relevant:

* [x] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [N/A] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
