### PR TITLE
Account for additional local memory requirements in Global dispatch

### DIFF
--- a/src/portfft/descriptor.hpp
+++ b/src/portfft/descriptor.hpp
@@ -368,11 +368,8 @@ class committed_descriptor {
     std::vector<std::tuple<detail::level, std::vector<sycl::kernel_id>, std::vector<Idx>>> param_vec;
     auto check_and_select_target_level = [&](IdxGlobal factor_size, bool batch_interleaved_layout = true) -> bool {
       constexpr std::size_t LocalRange = PORTFFT_SGS_IN_WG * SubgroupSize;
-      if (detail::fits_in_wi<Scalar>(factor_size) &&
-          static_cast<std::size_t>(local_memory_size) >
-              sizeof(Scalar) * 2 * LocalRange * static_cast<std::size_t>(factor_size)) {
-        // The local memory requirement (LocalRange * factor_size) is only required for the final factor.
-        // There is no way to know if this is the last factor, so it is always used.
+      if (detail::fits_in_wi<Scalar>(factor_size)) {
+        // Throughout we have assumed there would always be enough local memory for the WI implementation.
         param_vec.emplace_back(detail::level::WORKITEM,
                                detail::get_ids<detail::global_kernel, Scalar, Domain, SubgroupSize>(),
                                std::vector<Idx>{static_cast<Idx>(factor_size)});

--- a/src/portfft/descriptor.hpp
+++ b/src/portfft/descriptor.hpp
@@ -367,7 +367,6 @@ class committed_descriptor {
     }
     std::vector<std::tuple<detail::level, std::vector<sycl::kernel_id>, std::vector<Idx>>> param_vec;
     auto check_and_select_target_level = [&](IdxGlobal factor_size, bool batch_interleaved_layout = true) -> bool {
-      constexpr std::size_t LocalRange = PORTFFT_SGS_IN_WG * SubgroupSize;
       if (detail::fits_in_wi<Scalar>(factor_size)) {
         // Throughout we have assumed there would always be enough local memory for the WI implementation.
         param_vec.emplace_back(detail::level::WORKITEM,

--- a/src/portfft/descriptor.hpp
+++ b/src/portfft/descriptor.hpp
@@ -385,19 +385,19 @@ class committed_descriptor {
         IdxGlobal factor_wi = factor_size / factor_sg;
         if (detail::can_cast_safely<IdxGlobal, Idx>(factor_sg) && detail::can_cast_safely<IdxGlobal, Idx>(factor_wi)) {
           if (batch_interleaved_layout) {
-            // (local_memory_for_input + local_mem_for_store_modifier + local_mem_for_twiddles) < local_mem
-            return (sizeof(Scalar) *
-                    (num_scalars_in_local_mem<detail::layout::BATCH_INTERLEAVED>(
-                         detail::level::SUBGROUP, static_cast<std::size_t>(factor_size), SubgroupSize,
-                         {static_cast<Idx>(factor_sg), static_cast<Idx>(factor_wi)}, temp_num_sgs_in_wg) +
-                     static_cast<std::size_t>(factor_size) * LocalRange + 2 * static_cast<std::size_t>(factor_size))) <
+            return (2 *
+                        num_scalars_in_local_mem<detail::layout::BATCH_INTERLEAVED>(
+                            detail::level::SUBGROUP, static_cast<std::size_t>(factor_size), SubgroupSize,
+                            {static_cast<Idx>(factor_sg), static_cast<Idx>(factor_wi)}, temp_num_sgs_in_wg) *
+                        sizeof(Scalar) +
+                    2 * static_cast<std::size_t>(factor_size) * sizeof(Scalar)) <
                    static_cast<std::size_t>(local_memory_size);
           }
-          return (sizeof(Scalar) *
-                  (num_scalars_in_local_mem<detail::layout::PACKED>(
-                       detail::level::SUBGROUP, static_cast<std::size_t>(factor_size), SubgroupSize,
-                       {static_cast<Idx>(factor_sg), static_cast<Idx>(factor_wi)}, temp_num_sgs_in_wg) +
-                   static_cast<std::size_t>(factor_size) * LocalRange + 2 * static_cast<std::size_t>(factor_size))) <
+          return (num_scalars_in_local_mem<detail::layout::PACKED>(
+                      detail::level::SUBGROUP, static_cast<std::size_t>(factor_size), SubgroupSize,
+                      {static_cast<Idx>(factor_sg), static_cast<Idx>(factor_wi)}, temp_num_sgs_in_wg) *
+                      sizeof(Scalar) +
+                  2 * static_cast<std::size_t>(factor_size) * sizeof(Scalar)) <
                  static_cast<std::size_t>(local_memory_size);
         }
         return false;

--- a/src/portfft/dispatcher/global_dispatcher.hpp
+++ b/src/portfft/dispatcher/global_dispatcher.hpp
@@ -47,7 +47,7 @@ namespace detail {
 inline std::pair<IdxGlobal, IdxGlobal> get_launch_params(IdxGlobal fft_size, IdxGlobal num_batches, detail::level level,
                                                          Idx n_compute_units, Idx subgroup_size, Idx n_sgs_in_wg) {
   IdxGlobal n_available_sgs = 8 * n_compute_units * 64;
-  IdxGlobal wg_size = static_cast<IdxGlobal>(n_sgs_in_wg * subgroup_size);
+  IdxGlobal wg_size = n_sgs_in_wg * subgroup_size;
   if (level == detail::level::WORKITEM) {
     IdxGlobal n_ffts_per_wg = wg_size;
     IdxGlobal n_wgs_required = divide_ceil(num_batches, n_ffts_per_wg);

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -118,6 +118,13 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
                              ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}))),
                          test_params_print());
 
+// Selected individual tests in workgroup or global size range
+INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobalRegressionTest, FFTTest,
+                         ::testing::ConvertGenerator<basic_param_tuple>(
+                             ::testing::Combine(ip_packed_layout, fwd_only, interleaved_storage, ::testing::Values(3),
+                                                ::testing::Values(sizes_t{15360}))),
+                         test_params_print());
+
 // Sizes that use the global implementations
 INSTANTIATE_TEST_SUITE_P(GlobalTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -118,13 +118,6 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
                              ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}))),
                          test_params_print());
 
-// Selected individual tests in workgroup or global size range
-INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobalRegressionTest, FFTTest,
-                         ::testing::ConvertGenerator<basic_param_tuple>(
-                             ::testing::Combine(ip_packed_layout, fwd_only, interleaved_storage, ::testing::Values(3),
-                                                ::testing::Values(sizes_t{15360}))),
-                         test_params_print());
-
 // Sizes that use the global implementations
 INSTANTIATE_TEST_SUITE_P(GlobalTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(


### PR DESCRIPTION
* Not accounting for all local memory requirements in dispatch causes errors on A100.
* This PR accounts for the additional required memory.
* And also adds a regression test.
* This is not an ideal fix for the issue - the memory requirements depend on the ordering of the sub-impls. This information is not available at dispatch time. A more significant refactor is required.

## Checklist

Tick if relevant:

* [n/a] New files have a copyright
* [n/a] New headers have an include guards
* [n/a] API is documented with Doxygen
* [x] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
