### PR TITLE
Allocating correct amount of Local memory in Global Implementation

### DIFF
--- a/src/portfft/common/global.hpp
+++ b/src/portfft/common/global.hpp
@@ -474,7 +474,7 @@ std::vector<sycl::event> compute_level(
         return 1;
       }
       if (kd_struct.level == detail::level::SUBGROUP) {
-        return 2 * kd_struct.length * static_cast<std::size_t>(local_range / 2);
+        return detail::pad_local(2 * kd_struct.length * static_cast<std::size_t>(local_range / 2), std::size_t(1));
       }
     }
     return std::size_t(1);

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -115,7 +115,7 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupTest, FFTTest,
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_global_placement_layouts, fwd_only, interleaved_storage,
-                             ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}, sizes_t{15360}))),
+                             ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}))),
                          test_params_print());
 
 // Sizes that use the global implementations

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -113,10 +113,10 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupTest, FFTTest,
 
 // Sizes that can use either workgroup or Global implementation
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
-                         ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
-                             all_valid_global_placement_layouts, fwd_only, interleaved_storage,
-                             ::testing::Values(1, 128),
-                             ::testing::Values(sizes_t{8192}, sizes_t{16384}, sizes_t{9800}, sizes_t{68640}))),
+                         ::testing::ConvertGenerator<basic_param_tuple>(
+                             ::testing::Combine(all_valid_global_placement_layouts, fwd_only, interleaved_storage,
+                                                ::testing::Values(1, 128),
+                                                ::testing::Values(sizes_t{8192}, sizes_t{16384}, sizes_t{68640}))),
                          test_params_print());
 
 // Sizes that use the global implementations

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -113,10 +113,9 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupTest, FFTTest,
 
 // Sizes that can use either workgroup or Global implementation
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
-                         ::testing::ConvertGenerator<basic_param_tuple>(
-                             ::testing::Combine(all_valid_global_placement_layouts, fwd_only, interleaved_storage,
-                                                ::testing::Values(1, 128),
-                                                ::testing::Values(sizes_t{8192}, sizes_t{16384}, sizes_t{68640}))),
+                         ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
+                             all_valid_global_placement_layouts, fwd_only, interleaved_storage,
+                             ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}))),
                          test_params_print());
 
 // Sizes that use the global implementations

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -115,7 +115,8 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupTest, FFTTest,
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_global_placement_layouts, fwd_only, interleaved_storage,
-                             ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}))),
+                             ::testing::Values(1, 128),
+                             ::testing::Values(sizes_t{8192}, sizes_t{16384}, sizes_t{9800}, sizes_t{68640}))),
                          test_params_print());
 
 // Sizes that use the global implementations
@@ -123,6 +124,12 @@ INSTANTIATE_TEST_SUITE_P(GlobalTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_global_placement_layouts, fwd_only, interleaved_storage, ::testing::Values(1, 3),
                              ::testing::Values(sizes_t{32768}, sizes_t{65536}, sizes_t{131072}))),
+                         test_params_print());
+
+INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobalRegressionTest, FFTTest,
+                         ::testing::ConvertGenerator<basic_param_tuple>(
+                             ::testing::Combine(ip_packed_layout, fwd_only, interleaved_storage, ::testing::Values(3),
+                                                ::testing::Values(sizes_t{9800}, sizes_t{68640}))),
                          test_params_print());
 
 // Backward FFT test suite

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -115,7 +115,7 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupTest, FFTTest,
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_global_placement_layouts, fwd_only, interleaved_storage,
-                             ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}))),
+                             ::testing::Values(1, 128), ::testing::Values(sizes_t{8192}, sizes_t{16384}, sizes_t{15360}))),
                          test_params_print());
 
 // Sizes that use the global implementations

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -129,7 +129,7 @@ INSTANTIATE_TEST_SUITE_P(GlobalTest, FFTTest,
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobalRegressionTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(
                              ::testing::Combine(ip_packed_layout, fwd_only, interleaved_storage, ::testing::Values(3),
-                                                ::testing::Values(sizes_t{9800}, sizes_t{68640}))),
+                                                ::testing::Values(sizes_t{9800}))),
                          test_params_print());
 
 // Backward FFT test suite


### PR DESCRIPTION
<!-- Add short PR description here -->
In global.hpp, on line 473, it has not been taken into consideration that the local memory for modifiers is, in-fact padded, and only allocates non padded amount of local memory. 

After this fix, all tests on the opencl backend passes(at least locally !), and even fixes the issue with sizes 9800 and ~~68640~~ on SPIR-V backend

Borrows regression test suite from #127 
## Checklist

Tick if relevant:

* [NA] New files have a copyright
* [NA] New headers have an include guards
* [NA] API is documented with Doxygen
* [NA] New functionalities are tested
* [X] Tests pass locally
* [X] Files are clang-formatted
