### PR TITLE
Fix hang with subgroup implementation on Nvidia

### DIFF
--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -124,7 +124,7 @@ PORTFFT_INLINE void subgroup_impl(const T* input, T* output, const T* input_imag
   Idx n_cplx_per_sg = n_ffts_per_sg * fft_size;
   Idx n_reals_per_sg = n_ffts_per_sg * n_reals_per_fft;
   // id_of_fft_in_sg must be < n_ffts_per_sg. Subtraction ensure this for trailing work-items.
-  Idx id_of_fft_in_sg = subgroup_local_id / factor_sg - subgroup_local_id / (factor_sg * n_ffts_per_sg);
+  Idx id_of_fft_in_sg = subgroup_local_id / factor_sg - (subgroup_local_id >= factor_sg * n_ffts_per_sg);
   Idx id_of_wi_in_fft = subgroup_local_id % factor_sg;
   Idx n_ffts_per_wg = n_ffts_per_sg * n_sgs_in_wg;
 

--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -123,7 +123,8 @@ PORTFFT_INLINE void subgroup_impl(const T* input, T* output, const T* input_imag
   Idx fft_size = factor_sg * factor_wi;
   Idx n_cplx_per_sg = n_ffts_per_sg * fft_size;
   Idx n_reals_per_sg = n_ffts_per_sg * n_reals_per_fft;
-  Idx id_of_fft_in_sg = subgroup_local_id / factor_sg;
+  // id_of_fft_in_sg must be < n_ffts_per_sg. Subtraction ensure this for trailing work-items.
+  Idx id_of_fft_in_sg = subgroup_local_id / factor_sg - subgroup_local_id / (factor_sg * n_ffts_per_sg);
   Idx id_of_wi_in_fft = subgroup_local_id % factor_sg;
   Idx n_ffts_per_wg = n_ffts_per_sg * n_sgs_in_wg;
 

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -62,6 +62,8 @@ auto all_valid_multi_dim_placement_layouts = ::testing::ValuesIn(valid_multi_dim
 
 auto ip_packed_layout = ::testing::Values(
     test_placement_layouts_params{placement::IN_PLACE, detail::layout::PACKED, detail::layout::PACKED});
+auto ip_batch_interleaved_layout = ::testing::Values(
+    test_placement_layouts_params{placement::IN_PLACE, detail::layout::BATCH_INTERLEAVED, detail::layout::BATCH_INTERLEAVED});
 
 auto oop_packed_layout = ::testing::Values(
     test_placement_layouts_params{placement::OUT_OF_PLACE, detail::layout::PACKED, detail::layout::PACKED});
@@ -98,6 +100,12 @@ INSTANTIATE_TEST_SUITE_P(SubgroupTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_placement_layouts, fwd_only, complex_storages, ::testing::Values(1, 3, 555),
                              ::testing::Values(sizes_t{64}, sizes_t{96}, sizes_t{128}))),
+                         test_params_print());
+// sizes that use subgroup implementation
+INSTANTIATE_TEST_SUITE_P(SubgroupRegressionTest, FFTTest,
+                         ::testing::ConvertGenerator<basic_param_tuple>(
+                             ::testing::Combine(ip_batch_interleaved_layout, fwd_only, interleaved_storage,
+                                                ::testing::Values(44, 100), ::testing::Values(sizes_t{100}))),
                          test_params_print());
 // sizes that might use subgroup or workgroup implementation depending on device
 // and configurations

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -62,8 +62,8 @@ auto all_valid_multi_dim_placement_layouts = ::testing::ValuesIn(valid_multi_dim
 
 auto ip_packed_layout = ::testing::Values(
     test_placement_layouts_params{placement::IN_PLACE, detail::layout::PACKED, detail::layout::PACKED});
-auto ip_batch_interleaved_layout = ::testing::Values(
-    test_placement_layouts_params{placement::IN_PLACE, detail::layout::BATCH_INTERLEAVED, detail::layout::BATCH_INTERLEAVED});
+auto ip_batch_interleaved_layout = ::testing::Values(test_placement_layouts_params{
+    placement::IN_PLACE, detail::layout::BATCH_INTERLEAVED, detail::layout::BATCH_INTERLEAVED});
 
 auto oop_packed_layout = ::testing::Values(
     test_placement_layouts_params{placement::OUT_OF_PLACE, detail::layout::PACKED, detail::layout::PACKED});
@@ -103,9 +103,9 @@ INSTANTIATE_TEST_SUITE_P(SubgroupTest, FFTTest,
                          test_params_print());
 // sizes that use subgroup implementation
 INSTANTIATE_TEST_SUITE_P(SubgroupRegressionTest, FFTTest,
-                         ::testing::ConvertGenerator<basic_param_tuple>(
-                             ::testing::Combine(ip_batch_interleaved_layout, fwd_only, interleaved_storage,
-                                                ::testing::Values(44, 100), ::testing::Values(sizes_t{100}))),
+                         ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
+                             ip_batch_interleaved_layout, fwd_only, interleaved_storage, ::testing::Values(44, 100),
+                             ::testing::Values(sizes_t{80}, sizes_t{100}))),
                          test_params_print());
 // sizes that might use subgroup or workgroup implementation depending on device
 // and configurations


### PR DESCRIPTION
* Fixes hanging in sub-group implementation on Nvidia A100 for batch interleaved cases.
  * Hang caused by a loop with sub-group operations having 1 fewer iteration for work-items that are not in use due to subgroup size not being divisible by factor_sg.
  * 1 fewer iteration due to `id_of_fft_in_sub_batch` in [this](https://github.com/codeplaysoftware/portFFT/blob/0d864e8665093f1ffea0adeb1900dbcea090104c/src/portfft/dispatcher/subgroup_dispatcher.hpp#L219) loop being 1 larger then expected...
  * ... due to offset of 1 beyond expected range in `id_of_fft_in_sg` [here](https://github.com/codeplaysoftware/portFFT/blob/0d864e8665093f1ffea0adeb1900dbcea090104c/src/portfft/dispatcher/subgroup_dispatcher.hpp#L171).
  * This PR makes `id_of_fft_in_sg` always a value less than or equal to `n_ffts_per_sg`, so unused WIs do the same number of iterations as valid WIs.
* Add regression test.
  * Test confirmed to reproduce error in manual testing.

## Checklist

Tick if relevant:

* [n/a] New files have a copyright
* [n/a] New headers have an include guards
* [n/a] API is documented with Doxygen
* [x] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
