### PR TITLE
Correct factor parameter ordering in GLOBAL/SG (size 68640 bug)

### DIFF
--- a/src/portfft/dispatcher/global_dispatcher.hpp
+++ b/src/portfft/dispatcher/global_dispatcher.hpp
@@ -229,11 +229,11 @@ struct committed_descriptor<Scalar, Domain>::calculate_twiddles_struct::inner<de
         if (counter < kernels.size() - 1) {
           kernel_data.local_mem_required = desc.num_scalars_in_local_mem<detail::layout::BATCH_INTERLEAVED>(
               detail::level::SUBGROUP, static_cast<std::size_t>(factors_idx_global.at(counter)),
-              kernel_data.used_sg_size, {static_cast<Idx>(factor_sg), static_cast<Idx>(factor_wi)}, num_sgs_in_wg);
+              kernel_data.used_sg_size, {static_cast<Idx>(factor_wi), static_cast<Idx>(factor_sg)}, num_sgs_in_wg);
         } else {
           kernel_data.local_mem_required = desc.num_scalars_in_local_mem<detail::layout::PACKED>(
               detail::level::SUBGROUP, static_cast<std::size_t>(factors_idx_global.at(counter)),
-              kernel_data.used_sg_size, {static_cast<Idx>(factor_sg), static_cast<Idx>(factor_wi)}, num_sgs_in_wg);
+              kernel_data.used_sg_size, {static_cast<Idx>(factor_wi), static_cast<Idx>(factor_sg)}, num_sgs_in_wg);
         }
         auto [global_range, local_range] =
             detail::get_launch_params(factors_idx_global.at(counter), sub_batches.at(counter), detail::level::SUBGROUP,

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -138,7 +138,7 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
 INSTANTIATE_TEST_SUITE_P(GlobalTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_global_placement_layouts, fwd_only, interleaved_storage, ::testing::Values(1, 3),
-                             ::testing::Values(sizes_t{32768}, sizes_t{65536}, sizes_t{131072}))),
+                             ::testing::Values(sizes_t{32768}, sizes_t{68640}, sizes_t{65536}, sizes_t{131072}))),
                          test_params_print());
 
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobalRegressionTest, FFTTest,

--- a/test/unit_test/instantiate_fft_tests.hpp
+++ b/test/unit_test/instantiate_fft_tests.hpp
@@ -138,13 +138,13 @@ INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobal, FFTTest,
 INSTANTIATE_TEST_SUITE_P(GlobalTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(::testing::Combine(
                              all_valid_global_placement_layouts, fwd_only, interleaved_storage, ::testing::Values(1, 3),
-                             ::testing::Values(sizes_t{32768}, sizes_t{68640}, sizes_t{65536}, sizes_t{131072}))),
+                             ::testing::Values(sizes_t{32768}, sizes_t{65536}, sizes_t{131072}))),
                          test_params_print());
 
 INSTANTIATE_TEST_SUITE_P(WorkgroupOrGlobalRegressionTest, FFTTest,
                          ::testing::ConvertGenerator<basic_param_tuple>(
                              ::testing::Combine(ip_packed_layout, fwd_only, interleaved_storage, ::testing::Values(3),
-                                                ::testing::Values(sizes_t{9800}, sizes_t{15360}))),
+                                                ::testing::Values(sizes_t{9800}, sizes_t{15360}, sizes_t{68640}))),
                          test_params_print());
 
 // Backward FFT test suite


### PR DESCRIPTION
Sizes such as 68640 fail when using some build configurations. This is because of incorrect ordering of work-item/sub-group factors in the Global implementation.

This PR:
* Fixes the bug
* Adds a test that reproduces the issue (tested locally to confirm this).

## Checklist

Tick if relevant:

* [n/a] New files have a copyright
* [n/a] New headers have an include guards
* [n/a] API is documented with Doxygen
* [n/a] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
