### PR TITLE
Remove layout templates from src

### DIFF
--- a/src/portfft/common/workgroup.hpp
+++ b/src/portfft/common/workgroup.hpp
@@ -56,7 +56,6 @@ namespace detail {
 /**
  * Calculate all dfts in one dimension of the data stored in local memory.
  *
- * @tparam LayoutIn Input Layout
  * @tparam SubgroupSize Size of the subgroup
  * @tparam LocalT The type of the local view
  * @tparam T Scalar type
@@ -73,7 +72,7 @@ namespace detail {
  * @param stride_within_dft Stride between elements of each DFT - also the number of the DFTs in the inner dimension
  * @param ndfts_in_outer_dimension Number of DFTs in outer dimension
  * @param storage complex storage: interleaved or split
- * @param layout_in Input Layout
+ * @param input_layout the layout of the input data of the transforms
  * @param multiply_on_load Whether the input data is multiplied with some data array before fft computation.
  * @param MultiplyOnStore Whether the input data is multiplied with some data array after fft computation.
  * @param ApplyScaleFactor Whether or not the scale factor is applied
@@ -86,7 +85,7 @@ __attribute__((always_inline)) inline void dimension_dft(
     LocalT loc, T* loc_twiddles, const T* wg_twiddles, T scaling_factor, Idx max_num_batches_in_local_mem,
     Idx batch_num_in_local, const T* load_modifier_data, const T* store_modifier_data, IdxGlobal batch_num_in_kernel,
     Idx dft_size, Idx stride_within_dft, Idx ndfts_in_outer_dimension, complex_storage storage,
-    detail::layout layout_in, detail::elementwise_multiply multiply_on_load,
+    detail::layout input_layout, detail::elementwise_multiply multiply_on_load,
     detail::elementwise_multiply multiply_on_store, detail::apply_scale_factor apply_scale_factor,
     detail::complex_conjugate conjugate_on_load, detail::complex_conjugate conjugate_on_store,
     global_data_struct<1> global_data) {
@@ -149,7 +148,7 @@ __attribute__((always_inline)) inline void dimension_dft(
       working = working && static_cast<Idx>(global_data.sg.get_local_linear_id()) < max_working_tid_in_sg;
     }
     if (working) {
-      if (layout_in == detail::layout::BATCH_INTERLEAVED) {
+      if (input_layout == detail::layout::BATCH_INTERLEAVED) {
         global_data.log_message_global(__func__, "loading transposed data from local to private memory");
         if (storage == complex_storage::INTERLEAVED_COMPLEX) {
           detail::strided_view local_view{
@@ -249,7 +248,7 @@ __attribute__((always_inline)) inline void dimension_dft(
         }
       }
       global_data.log_dump_private("data in registers after computation:", priv, 2 * fact_wi);
-      if (layout_in == detail::layout::BATCH_INTERLEAVED) {
+      if (input_layout == detail::layout::BATCH_INTERLEAVED) {
         global_data.log_message_global(__func__, "storing transposed data from private to local memory");
         if (storage == complex_storage::INTERLEAVED_COMPLEX) {
           detail::strided_view local_view{
@@ -313,7 +312,7 @@ __attribute__((always_inline)) inline void dimension_dft(
  * @param N Smaller factor of the Problem size
  * @param M Larger factor of the problem size
  * @param storage complex storage: interleaved or split
- * @param layout_in Whether or not the input is transposed
+ * @param input_layout the layout of the input data of the transforms
  * @param multiply_on_load Whether the input data is multiplied with some data array before fft computation.
  * @param multiply_on_store Whether the input data is multiplied with some data array after fft computation.
  * @param apply_scale_factor Whether or not the scale factor is applied
@@ -325,7 +324,7 @@ template <Idx SubgroupSize, typename LocalT, typename T>
 PORTFFT_INLINE void wg_dft(LocalT loc, T* loc_twiddles, const T* wg_twiddles, T scaling_factor,
                            Idx max_num_batches_in_local_mem, Idx batch_num_in_local, IdxGlobal batch_num_in_kernel,
                            const T* load_modifier_data, const T* store_modifier_data, Idx fft_size, Idx N, Idx M,
-                           complex_storage storage, detail::layout layout_in,
+                           complex_storage storage, detail::layout input_layout,
                            detail::elementwise_multiply multiply_on_load,
                            detail::elementwise_multiply multiply_on_store,
                            detail::apply_scale_factor apply_scale_factor, detail::complex_conjugate conjugate_on_load,
@@ -336,14 +335,14 @@ PORTFFT_INLINE void wg_dft(LocalT loc, T* loc_twiddles, const T* wg_twiddles, T 
   // column-wise DFTs
   detail::dimension_dft<SubgroupSize, LocalT, T>(
       loc, loc_twiddles + (2 * M), nullptr, 1, max_num_batches_in_local_mem, batch_num_in_local, load_modifier_data,
-      store_modifier_data, batch_num_in_kernel, N, M, 1, storage, layout_in, multiply_on_load,
+      store_modifier_data, batch_num_in_kernel, N, M, 1, storage, input_layout, multiply_on_load,
       detail::elementwise_multiply::NOT_APPLIED, detail::apply_scale_factor::NOT_APPLIED, conjugate_on_load,
       detail::complex_conjugate::NOT_APPLIED, global_data);
   sycl::group_barrier(global_data.it.get_group());
   // row-wise DFTs, including twiddle multiplications and scaling
   detail::dimension_dft<SubgroupSize, LocalT, T>(
       loc, loc_twiddles, wg_twiddles, scaling_factor, max_num_batches_in_local_mem, batch_num_in_local,
-      load_modifier_data, store_modifier_data, batch_num_in_kernel, M, 1, N, storage, layout_in,
+      load_modifier_data, store_modifier_data, batch_num_in_kernel, M, 1, N, storage, input_layout,
       detail::elementwise_multiply::NOT_APPLIED, multiply_on_store, apply_scale_factor,
       detail::complex_conjugate::NOT_APPLIED, conjugate_on_store, global_data);
   global_data.log_message_global(__func__, "exited");

--- a/src/portfft/utils.hpp
+++ b/src/portfft/utils.hpp
@@ -43,35 +43,23 @@ class transpose_kernel;
  * @tparam SubgroupSize size of the subgroup
  * @return vector of kernel ids
  */
-template <template <typename, domain, detail::memory, detail::layout, detail::layout, Idx> class Kernel,
-          typename Scalar, domain Domain, Idx SubgroupSize>
+template <template <typename, domain, detail::memory, Idx> class Kernel, typename Scalar, domain Domain,
+          Idx SubgroupSize>
 std::vector<sycl::kernel_id> get_ids() {
   PORTFFT_LOG_FUNCTION_ENTRY();
   std::vector<sycl::kernel_id> ids;
-#define PORTFFT_GET_ID(MEMORY, LAYOUT_IN, LAYOUT_OUT)                                                          \
-  try {                                                                                                        \
-    ids.push_back(sycl::get_kernel_id<Kernel<Scalar, Domain, MEMORY, LAYOUT_IN, LAYOUT_OUT, SubgroupSize>>()); \
-  } catch (...) {                                                                                              \
+  try {
+    ids.push_back(sycl::get_kernel_id<Kernel<Scalar, Domain, memory::USM, SubgroupSize>>());
+  } catch (...) {
   }
 
-#define INSTANTIATE_LAYOUTIN_LAYOUT_MODIFIERS(MEM, LAYOUT_IN) \
-  PORTFFT_GET_ID(MEM, LAYOUT_IN, layout::BATCH_INTERLEAVED)   \
-  PORTFFT_GET_ID(MEM, LAYOUT_IN, layout::PACKED)
-
-#define INSTANTIATE_MEM_LAYOUTS_MODIFIERS(MEM)                          \
-  INSTANTIATE_LAYOUTIN_LAYOUT_MODIFIERS(MEM, layout::BATCH_INTERLEAVED) \
-  INSTANTIATE_LAYOUTIN_LAYOUT_MODIFIERS(MEM, layout::PACKED)
-
 #ifdef PORTFFT_ENABLE_BUFFER_BUILDS
-  INSTANTIATE_MEM_LAYOUTS_MODIFIERS(memory::USM)
-  INSTANTIATE_MEM_LAYOUTS_MODIFIERS(memory::BUFFER)
-#else
-  INSTANTIATE_MEM_LAYOUTS_MODIFIERS(memory::USM)
+  try {
+    ids.push_back(sycl::get_kernel_id<Kernel<Scalar, Domain, memory::BUFFER, SubgroupSize>>());
+  } catch (...) {
+  }
 #endif
 
-#undef PORTFFT_GET_ID
-#undef INSTANTIATE_LAYOUTIN_LAYOUT_MODIFIERS
-#undef INSTANTIATE_MEM_LAYOUTS_MODIFIERS
   return ids;
 }
 

--- a/test/common/reference_data_wrangler.hpp
+++ b/test/common/reference_data_wrangler.hpp
@@ -96,16 +96,16 @@ std::vector<InType> reshape_to_desc(const std::vector<InType>& in, const Descrip
  * @tparam Domain domain of the FFT
  * @param desc The description of the FFT
  * @param padding_value The value to use in memory locations that are not expected to be read or written.
- * @param layout_in layout (PACKED/BATCH_INTERLEAVED) of the input data
- * @param layout_out layout (PACKED/BATCH_INTERLEAVED) of the output data
+ * @param input_layout layout (PACKED/BATCH_INTERLEAVED) of the input data
+ * @param output_layout layout (PACKED/BATCH_INTERLEAVED) of the output data
  * @return a tuple of vectors containing input and output data for a problem with the given descriptor. If `Storage` is
  *interleaved the first two tuple values contain vectors of input and output data and the last two vectors are empty. If
  *`Storage` is split, first two values contain input and output real part and the last two input and output imaginary
  *part of the data.
  **/
 template <portfft::direction Dir, portfft::complex_storage Storage, typename Scalar, portfft::domain Domain>
-auto gen_fourier_data(portfft::descriptor<Scalar, Domain>& desc, portfft::detail::layout layout_in,
-                      portfft::detail::layout layout_out, float padding_value) {
+auto gen_fourier_data(portfft::descriptor<Scalar, Domain>& desc, portfft::detail::layout input_layout,
+                      portfft::detail::layout output_layout, float padding_value) {
   constexpr bool IsRealDomain = Domain == portfft::domain::REAL;
   constexpr bool IsForward = Dir == portfft::direction::FORWARD;
   constexpr bool IsInterleaved = Storage == portfft::complex_storage::INTERLEAVED_COMPLEX;
@@ -209,8 +209,8 @@ auto gen_fourier_data(portfft::descriptor<Scalar, Domain>& desc, portfft::detail
     std::for_each(forward.begin(), forward.end(), [scaling_factor](auto& x) { x *= scaling_factor; });
   }
 
-  const auto layout_fwd = IsForward ? layout_in : layout_out;
-  const auto layout_bwd = IsForward ? layout_out : layout_in;
+  const auto layout_fwd = IsForward ? input_layout : output_layout;
+  const auto layout_bwd = IsForward ? output_layout : input_layout;
 
   // modify layout
   forward = reshape_to_desc(forward, desc, layout_fwd, portfft::direction::FORWARD, padding_value);


### PR DESCRIPTION
There should be no user facing changes here.
I've removed the layout templates because this will all happen as support for strided transforms increases and I thought it would be helpful to just do it all at once.
As an added bonus, the runtime for the test suite is much faster for intel backends after this change, due to shorter kernel bundle build times.

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [x] API is documented with Doxygen
* [N/A] New functionalities are tested
* [x] Tests pass locally
* [x] Files are clang-formatted
