### PR TITLE
Enable dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    reviewers:
+      - "codeplaysoftware/security-managers"

--- a/.github/workflows/check_clang_format.yml
+++ b/.github/workflows/check_clang_format.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Code checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Is-clang-formatted hook
         run:  ./hooks/is-clang-formatted.sh
       - name: Show diff


### PR DESCRIPTION
The aim of dependency pinning is avoiding supply chain vulnerabilities. OpenSSF scorecard recommends pinning to the actions hash to avoid the situation where a dependency action introduces a vulnerability. Dependabot will check dependencies versions and flag any version with vulnerabilities to be updated.

Dependabot updates will happen once a month. To avoid PR noise to developers, organization level team "security managers" will receive the notification for review.

## Checklist

Tick if relevant:

* [ ] New files have a copyright
* [ ] New headers have an include guards
* [ ] API is documented with Doxygen
* [ ] New functionalities are tested
* [ ] Tests pass locally
* [ ] Files are clang-formatted
