### PR TITLE
Fix google benchmarks interaction with CXXFLAGS with -fsycl

### DIFF
--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -29,14 +29,20 @@ find_package(SYCL)
 set(BENCHMARK_ENABLE_TESTING OFF)
 # The icpx compiler causes errors when in release mode:
 set(BENCHMARK_ENABLE_WERROR OFF)
+
+# The -fsycl sometimes passed through CMAKE_CXX_FLAGS requires C++17 which is
+# incompatible with the C++ version required by benchmark.
+set(CMAKE_CXX_FLAGS_TMP ${CMAKE_CXX_FLAGS})
+set(CMAKE_CXX_FLAGS "")
 # Fetch googlebenchmark:
 include(FetchContent)
 FetchContent_Declare(
     googlebenchmark
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.7.1
+    GIT_TAG v1.8.5
 )
 FetchContent_MakeAvailable(googlebenchmark)
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_TMP})
 
 # Common function to add a benchmark
 set(BENCHMARK_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
* The Google Benchmark code does not work if CMAKE_CXX_FLAGS include -fsycl due to conflicting C++ version requirements.
* This removes the external CXX flags for the Google Benchmark library build.
* Also update Google Benchmark version tag.

## Checklist

Tick if relevant:

* [N/A] New files have a copyright
* [N/A] New headers have an include guards
* [N/A] API is documented with Doxygen
* [x] New functionalities are tested
* [N/A] Tests pass locally
* [N/A] Files are clang-formatted
