### PR TITLE
Correct private memory allocations in the SCLA path

### DIFF
--- a/src/portfft/committed_descriptor_impl.hpp
+++ b/src/portfft/committed_descriptor_impl.hpp
@@ -354,8 +354,8 @@ class committed_descriptor_impl {
     PORTFFT_LOG_TRACE("Setting specialization constants:");
     PORTFFT_LOG_TRACE("SpecConstComplexStorage:", params.complex_storage);
     in_bundle.template set_specialization_constant<detail::SpecConstComplexStorage>(params.complex_storage);
-    PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * length);
-    in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
+    // PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * length);
+    // in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
     // PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
     // in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
     PORTFFT_LOG_TRACE("SpecConstMultiplyOnLoad:", multiply_on_load);

--- a/src/portfft/committed_descriptor_impl.hpp
+++ b/src/portfft/committed_descriptor_impl.hpp
@@ -354,10 +354,6 @@ class committed_descriptor_impl {
     PORTFFT_LOG_TRACE("Setting specialization constants:");
     PORTFFT_LOG_TRACE("SpecConstComplexStorage:", params.complex_storage);
     in_bundle.template set_specialization_constant<detail::SpecConstComplexStorage>(params.complex_storage);
-    // PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * length);
-    // in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
-    // PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
-    // in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
     PORTFFT_LOG_TRACE("SpecConstMultiplyOnLoad:", multiply_on_load);
     in_bundle.template set_specialization_constant<detail::SpecConstMultiplyOnLoad>(multiply_on_load);
     PORTFFT_LOG_TRACE("SpecConstMultiplyOnStore:", multiply_on_store);

--- a/src/portfft/committed_descriptor_impl.hpp
+++ b/src/portfft/committed_descriptor_impl.hpp
@@ -356,8 +356,8 @@ class committed_descriptor_impl {
     in_bundle.template set_specialization_constant<detail::SpecConstComplexStorage>(params.complex_storage);
     PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * length);
     in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
-    PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
-    in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
+    // PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
+    // in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
     PORTFFT_LOG_TRACE("SpecConstMultiplyOnLoad:", multiply_on_load);
     in_bundle.template set_specialization_constant<detail::SpecConstMultiplyOnLoad>(multiply_on_load);
     PORTFFT_LOG_TRACE("SpecConstMultiplyOnStore:", multiply_on_store);

--- a/src/portfft/common/workgroup.hpp
+++ b/src/portfft/common/workgroup.hpp
@@ -79,8 +79,8 @@ namespace detail {
  * @param conjugate_on_load whether or not to conjugate the input
  * @param conjugate_on_store whether or not to conjugate the output
  * @param global_data global data for the kernel
- * @param wi_impl_scratch_space_ptr pointer to the scratch space required by the work-item implementation
- * @param priv_ptr pointer to the private memory to be used by the work-group implementation
+ * @param wi_private_scratch pointer to the scratch space required by the work-item implementation
+ * @param priv pointer to the private memory to be used by the work-group implementation
  */
 template <Idx SubgroupSize, typename LocalT, typename T>
 __attribute__((always_inline)) inline void dimension_dft(

--- a/src/portfft/common/workgroup.hpp
+++ b/src/portfft/common/workgroup.hpp
@@ -79,6 +79,8 @@ namespace detail {
  * @param conjugate_on_load whether or not to conjugate the input
  * @param conjugate_on_store whether or not to conjugate the output
  * @param global_data global data for the kernel
+ * @param wi_impl_scratch_space_ptr pointer to the scratch space required by the work-item implementation
+ * @param priv_ptr pointer to the private memory to be used by the work-group implementation
  */
 template <Idx SubgroupSize, typename LocalT, typename T>
 __attribute__((always_inline)) inline void dimension_dft(
@@ -311,6 +313,8 @@ __attribute__((always_inline)) inline void dimension_dft(
  * @param conjugate_on_load whether or not to conjugate the input
  * @param conjugate_on_store whether or not to conjugate the output
  * @param global_data global data for the kernel
+ * @param wi_impl_scratch_space_ptr pointer to the scratch space required by the work-item implementation
+ * @param priv_ptr pointer to the private memory to be used by the work-group implementation
  */
 template <Idx SubgroupSize, typename LocalT, typename T>
 PORTFFT_INLINE void wg_dft(LocalT loc, T* loc_twiddles, const T* wg_twiddles, T scaling_factor,

--- a/src/portfft/dispatcher/global_dispatcher.hpp
+++ b/src/portfft/dispatcher/global_dispatcher.hpp
@@ -277,14 +277,14 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
       in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
     }
     if (level == detail::level::WORKGROUP) {
+      auto num_cpx_in_private_mem = std::max(factors[1], factors[3]);
       PORTFFT_LOG_TRACE("SpecConstFftSize:", length);
       in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
-      PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(std::max(factors[1], factors[3])));
+      PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(num_cpx_in_private_mem));
       in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(
-          2 * detail::wi_temps(std::max(factors[1], factors[3])));
-      PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * factors[0]);
-      in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 *
-                                                                                      std::max(factors[1], factors[3]));
+          2 * detail::wi_temps(num_cpx_in_private_mem));
+      PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * num_cpx_in_private_mem);
+      in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * num_cpx_in_private_mem);
     } else if (level == detail::level::SUBGROUP) {
       PORTFFT_LOG_TRACE("SubgroupFactorWISpecConst:", factors[1]);
       in_bundle.template set_specialization_constant<detail::SubgroupFactorWISpecConst>(factors[1]);

--- a/src/portfft/dispatcher/global_dispatcher.hpp
+++ b/src/portfft/dispatcher/global_dispatcher.hpp
@@ -268,14 +268,32 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
     in_bundle.template set_specialization_constant<detail::GlobalSpecConstNumFactors>(num_factors);
     PORTFFT_LOG_TRACE("GlobalSpecConstLevelNum:", factor_num);
     in_bundle.template set_specialization_constant<detail::GlobalSpecConstLevelNum>(factor_num);
-    if (level == detail::level::WORKITEM || level == detail::level::WORKGROUP) {
+    if (level == detail::level::WORKITEM) {
       PORTFFT_LOG_TRACE("SpecConstFftSize:", length);
       in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
+      PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
+      in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
+      PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * length);
+      in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
+    }
+    if (level == detail::level::WORKGROUP) {
+      PORTFFT_LOG_TRACE("SpecConstFftSize:", length);
+      in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
+      PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(std::max(factors[1], factors[3])));
+      in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(
+          2 * detail::wi_temps(std::max(factors[1], factors[3])));
+      PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * factors[0]);
+      in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 *
+                                                                                      std::max(factors[1], factors[3]));
     } else if (level == detail::level::SUBGROUP) {
       PORTFFT_LOG_TRACE("SubgroupFactorWISpecConst:", factors[1]);
       in_bundle.template set_specialization_constant<detail::SubgroupFactorWISpecConst>(factors[1]);
       PORTFFT_LOG_TRACE("SubgroupFactorSGSpecConst:", factors[0]);
       in_bundle.template set_specialization_constant<detail::SubgroupFactorSGSpecConst>(factors[0]);
+      PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(factors[1]));
+      in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(factors[1]));
+      PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * factors[1]);
+      in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * factors[1]);
     }
   }
 };

--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -764,6 +764,8 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
     in_bundle.template set_specialization_constant<detail::SubgroupFactorWISpecConst>(factors[0]);
     PORTFFT_LOG_TRACE("SubgroupFactorSGSpecConst:", factors[1]);
     in_bundle.template set_specialization_constant<detail::SubgroupFactorSGSpecConst>(factors[1]);
+    PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(factors[0]));
+    in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(factors[0]));
   }
 };
 

--- a/src/portfft/dispatcher/subgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/subgroup_dispatcher.hpp
@@ -766,6 +766,8 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
     in_bundle.template set_specialization_constant<detail::SubgroupFactorSGSpecConst>(factors[1]);
     PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(factors[0]));
     in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(factors[0]));
+    PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * factors[0]);
+    in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * factors[0]);
   }
 };
 

--- a/src/portfft/dispatcher/workgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/workgroup_dispatcher.hpp
@@ -349,15 +349,15 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
   static void execute(committed_descriptor_impl& /*desc*/, sycl::kernel_bundle<sycl::bundle_state::input>& in_bundle,
                       Idx length, const std::vector<Idx>& factors, detail::level /*level*/, Idx /*factor_num*/,
                       Idx /*num_factors*/) {
+    auto num_cpx_in_private_mem = std::max(factors[1], factors[3]);
     PORTFFT_LOG_FUNCTION_ENTRY();
     PORTFFT_LOG_TRACE("SpecConstFftSize:", length);
     in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
-    PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(std::max(factors[1], factors[3])));
+    PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(num_cpx_in_private_mem));
     in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(
-        2 * detail::wi_temps(std::max(factors[1], factors[3])));
-    PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * factors[0]);
-    in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 *
-                                                                                    std::max(factors[1], factors[3]));
+        2 * detail::wi_temps(num_cpx_in_private_mem));
+    PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * num_cpx_in_private_mem);
+    in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * num_cpx_in_private_mem);
   }
 };
 

--- a/src/portfft/dispatcher/workgroup_dispatcher.hpp
+++ b/src/portfft/dispatcher/workgroup_dispatcher.hpp
@@ -338,11 +338,14 @@ template <typename Scalar, domain Domain>
 template <typename Dummy>
 struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inner<detail::level::WORKGROUP, Dummy> {
   static void execute(committed_descriptor_impl& /*desc*/, sycl::kernel_bundle<sycl::bundle_state::input>& in_bundle,
-                      Idx length, const std::vector<Idx>& /*factors*/, detail::level /*level*/, Idx /*factor_num*/,
+                      Idx length, const std::vector<Idx>& factors, detail::level /*level*/, Idx /*factor_num*/,
                       Idx /*num_factors*/) {
     PORTFFT_LOG_FUNCTION_ENTRY();
     PORTFFT_LOG_TRACE("SpecConstFftSize:", length);
     in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
+    PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(std::max(factors[1], factors[3])));
+    in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(
+        2 * detail::wi_temps(std::max(factors[1], factors[3])));
   }
 };
 

--- a/src/portfft/dispatcher/workitem_dispatcher.hpp
+++ b/src/portfft/dispatcher/workitem_dispatcher.hpp
@@ -415,6 +415,8 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
     PORTFFT_LOG_FUNCTION_ENTRY();
     PORTFFT_LOG_TRACE("SpecConstFftSize:", length);
     in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
+    PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
+    in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
   }
 };
 

--- a/src/portfft/dispatcher/workitem_dispatcher.hpp
+++ b/src/portfft/dispatcher/workitem_dispatcher.hpp
@@ -417,6 +417,8 @@ struct committed_descriptor_impl<Scalar, Domain>::set_spec_constants_struct::inn
     in_bundle.template set_specialization_constant<detail::SpecConstFftSize>(length);
     PORTFFT_LOG_TRACE("SpecConstWIScratchSize:", 2 * detail::wi_temps(length));
     in_bundle.template set_specialization_constant<detail::SpecConstWIScratchSize>(2 * detail::wi_temps(length));
+    PORTFFT_LOG_TRACE("SpecConstNumRealsPerFFT:", 2 * length);
+    in_bundle.template set_specialization_constant<detail::SpecConstNumRealsPerFFT>(2 * length);
   }
 };
 

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -29,20 +29,14 @@ find_package(SYCL)
 set(BENCHMARK_ENABLE_TESTING OFF)
 # The icpx compiler causes errors when in release mode:
 set(BENCHMARK_ENABLE_WERROR OFF)
-
-# The -fsycl sometimes passed through CMAKE_CXX_FLAGS requires C++17 which is
-# incompatible with the C++ version required by benchmark.
-set(CMAKE_CXX_FLAGS_TMP ${CMAKE_CXX_FLAGS})
-set(CMAKE_CXX_FLAGS "")
 # Fetch googlebenchmark:
 include(FetchContent)
 FetchContent_Declare(
     googlebenchmark
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.8.5
+    GIT_TAG v1.7.1
 )
 FetchContent_MakeAvailable(googlebenchmark)
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_TMP})
 
 # Common function to add a benchmark
 set(BENCHMARK_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/test/bench/portfft/launch_bench.hpp
+++ b/test/bench/portfft/launch_bench.hpp
@@ -22,7 +22,6 @@
 #define PORTFFT_BENCH_LAUNCH_BENCH_HPP
 
 #include <cassert>
-#include <limits>
 #include <sstream>
 #include <type_traits>
 
@@ -103,6 +102,8 @@ void bench_dft_average_host_time_impl(benchmark::State& state, sycl::queue q, po
 #endif  // PORTFFT_VERIFY_BENCHMARKS
   std::vector<sycl::event> dependencies;
   dependencies.reserve(1);
+  state.counters["flops"] = 0;
+  state.counters["throughput"] = 0;
   for (auto _ : state) {
     // we need to manually measure time, so as to have it available here for the
     // calculation of flops
@@ -214,6 +215,8 @@ void bench_dft_device_time_impl(benchmark::State& state, sycl::queue q, portfft:
   verify_dft<portfft::direction::FORWARD, portfft::complex_storage::INTERLEAVED_COMPLEX>(desc, backward_data,
                                                                                          host_output, 1e-2);
 #endif  // PORTFFT_VERIFY_BENCHMARKS
+  state.counters["flops"] = 0;
+  state.counters["throughput"] = 0;
   for (auto _ : state) {
     // Write to the input to invalidate cache
     q.copy(host_forward_data.data(), in_dev.get(), num_elements).wait();


### PR DESCRIPTION
<!-- Add short PR description here -->
Corrects the allocation size of the private arrays in the SCLA path, which was otherwise leading to spills and hence poor performance even when using SCLAs.

Also brings in a minor fix in the benchmarks. Turns out we were only reporting the last value instead of the average.

tag @victor-eds 

tag @Rbiessy @hjabird 

Already Merges: #149 
## Checklist

Tick if relevant:

* [] New files have a copyright
* [] New headers have an include guards
* [X] API is documented with Doxygen
* [X] New functionalities are tested
* [X] Tests pass locally
* [X] Files are clang-formatted
